### PR TITLE
[Flashing.md] remove Ubuntu/Debian instructions

### DIFF
--- a/installation/Flashing.md
+++ b/installation/Flashing.md
@@ -45,10 +45,6 @@ Go to the folder and install Esptool with command
 ```
 python setup.py install
 ```
-Esptool for [Debian](https://packages.debian.org/stretch/esptool) and [Ubuntu](https://packages.ubuntu.com/cosmic/esptool) is installed with 
-```bash
-sudo apt install esptool
-```
 
 #### Upload Tasmota
 Make sure you followed the steps to put your device in flash mode. Place your chosen firmware binary file in the same folder as esptool.py.


### PR DESCRIPTION
Ubuntu and Debian instructions suggest to install esptool using apt.
However (at least on Ubuntu 18.04) this gives esptool 2.1.
That version is not suitable to program tasmota as commands like
erase_flash do not work.

Solution is to always use the latest esptool.py
Therefore removed the Ubuntu/Debian specific lines.

Signed-off-by: Frans Meulenbroeks <fransmeulenbroeks@yahoo.com>