### PR TITLE
Fix returned json value on flash

### DIFF
--- a/Sonoff-DIY.md
+++ b/Sonoff-DIY.md
@@ -109,7 +109,7 @@ This procedure is recommended for MacOS, but also works for Linux.
 - Flash firmware at `/zeroconf/ota_flash`  
   > `$ curl http://<deviceIP>:8081/zeroconf/ota_flash -XPOST --data '{"deviceid":"<deviceID>","data":{"downloadUrl": "http://<webServer>/tasmota-wifiman.bin", "sha256sum": "<SHAsum>"} }'`  
 
-  **_`{"seq":2,"error":0}`_**  
+  **_`{"seq":3,"error":0}`_**  
 - Ping the device for about 30 seconds until it has rebooted
 
 ## Post Installation


### PR DESCRIPTION
While flashing my new device I found that the documentation about the command result is wrong.

Here is the output from my run:
```
$ curl http://192.168.127.101:8081/zeroconf/ota_flash -XPOST --data '{"deviceid":"1000a03c93","data":{"downloadUrl": "http://192.168.127.100:8085/tasmota-wifiman.bin", "sha256sum": "178fc2262a3bdff2fb6219424d7f00e02a6da4bb6bd0e2681d1178014f635231"} }'
{"seq":3,"error":0}
```