### PR TITLE
add EspBuddy Tool

### DIFF
--- a/installation/Flashing.md
+++ b/installation/Flashing.md
@@ -158,6 +158,7 @@ _**Can only create a firmware binary.** Use one of the [tools](/installation/Pre
 
 ## OTA Flashing Tools
 **Tasmota is NOT a developer of these tools. For help and troubleshooting you will need to _get support from those projects_.**
+- [**EspBuddy**](https://github.com/soif/EspBuddy) - OTA  or serial flash (using intermediate firmware for 1M devices), backup settings and past firmwares, auto-build using custom flags, flash in batch, handle Sonoff DIY devices...
 - [**Tuya Convert**](Tuya-Convert) - easy OTA flash for devices with Tuya chips, no disassembly required
 - [**Sonoff DIY**](Sonoff-DIY) - OTA flash for select Sonoff devices (some disassembly required)
 - [**Node-RED OTA server and firmware manager**](https://flows.nodered.org/flow/888b4cd95250197eb429b2f40d188185) - [Node-RED](https://nodered.org/) flow for managing OTA updates 


### PR DESCRIPTION
## EspBuddy
https://github.com/soif/EspBuddy

- Handle Tasmota flashing via serial or OTA and even automating "2 steps" OTA uploads (using an intermediate firmware)
- all flash operation can be performed in batch mode (ie build and upload to dozen of devices, in one simple command, ie:` espbuddy upload ALL`)
- I've just added a **sonodiy** mode to scan/control/flash Sonoff DIY devices from the factory firmware. Tasmota firmware is the default one.
- cross-platform: osx, linux, windows (with some limitations)

This is the swiss army knife for ESP8266 based devices ... Try it!