### PR TITLE
Fixed typo "autodiscovery"

### DIFF
--- a/integrations/Home-Assistant.md
+++ b/integrations/Home-Assistant.md
@@ -915,7 +915,7 @@ automation:
 For manually configured devices:
 ```yaml
 automation:
-  - alias: "Sync Tasmota states on start-up - autodiscovery"
+  - alias: "Sync Tasmota states on start-up - manual configuration"
     initial_state: true
     trigger:
       platform: homeassistant


### PR DESCRIPTION
Alias should reflect what code snippet is for.