### PR TITLE
Fix links on the "FAQ and Troubleshooting" page

### DIFF
--- a/help/README.md
+++ b/help/README.md
@@ -1,6 +1,6 @@
 > [!TIP]
 > If you cannot find an answer to your problem visit out [Discord](https://discord.gg/Ks2Kzd4)
 
-# [FAQ](FAQ)
-# [Troubleshooting](Troubleshooting)
-# [Device Recovery](Device-Recovery)
+# [FAQ](help/FAQ)
+# [Troubleshooting](help/Troubleshooting)
+# [Device Recovery](help/Device-Recovery)


### PR DESCRIPTION
All links on https://tasmota.github.io/docs/#/help/ end with 404 pages (for example FAQ points to incorrect URL`https://tasmota.github.io/docs/#/FAQ` instead of the correct one `https://tasmota.github.io/docs/#/help/FAQ`).

I'm not sure if my change fixes it (I'm not able to test it), so please check it before merging.