### PR TITLE
Details if OTA yourbinary.bin is more thant 500KB

### DIFF
--- a/Upgrading.md
+++ b/Upgrading.md
@@ -33,9 +33,9 @@ Install Python3 and from the folder where the binary resides (make sure `tasmota
 ```
 python -m http.server 8000
 ```
-Change your OtaUrl to http://ipoftheserver:8000/yourbinary.bin and start the upgrade process.
+Change your OtaUrl to http://ipoftheserver:8000/yourbinary.bin and start the upgrade process. Note: do not use `/`, `-`, or `.` characters in the name of `yourbinary`.
 
-If your binary build (yourbinary.bin) is more than 500KB, Tasmota will need to install first the minial version and after install yourbinary.bin . To have this OTA process working, you have to copy the file tasmota-minimal.bin, and paste/change it's name to yourbinary-minimal.bin, and put it in the same folder of yourbinary.bin, then OTA process will work (Note: do not put "/", "-", "." characheter in "yourbinary").
+If your binary build (yourbinary.bin) is larger than the available free flash program space, Tasmota will need to first install the minimal version of Tasmota to make more space. To have this work via the web server OTA process, you have to copy the file `tasmota-minimal.bin` in the same folder where `OTAURL` for `yourbinary.bin` is placed.
 
 ### By File Upload
 This process requires you to have a minimal build `tasmota-minimal.bin` of the firmware since the upload process needs the space in flash memory to upload the new binary. 

--- a/Upgrading.md
+++ b/Upgrading.md
@@ -35,6 +35,8 @@ python -m http.server 8000
 ```
 Change your OtaUrl to http://ipoftheserver:8000/yourbinary.bin and start the upgrade process.
 
+If your binary build (yourbinary.bin) is more than 500KB, Tasmota will need to install first the minial version and after install yourbinary.bin . To have this OTA process working, you have to copy the file tasmota-minimal.bin, and paste/change it's name to yourbinary-minimal.bin, and put it in the same folder of yourbinary.bin, then OTA process will work (Note: do not put "/", "-", "." characheter in "yourbinary").
+
 ### By File Upload
 This process requires you to have a minimal build `tasmota-minimal.bin` of the firmware since the upload process needs the space in flash memory to upload the new binary. 
 


### PR DESCRIPTION
I needed to upgrade by OTA my custom build "yourbinary.bin" with more than 500KB ... but it didn't work easyly: I need to manually update minimal first, thent manually update my firmware. But by checking the code (support_tasmota.ino), I seen that by creating yourbinary-minimal.bin myself on my OTA server (a copy of tasmota-minimal.bin), it work's fluently ! I add this information to help other ! (didn't seen this information on the doc).

Nicolas.
PS: And congrats to Tasmota work, and long life ! A really amazing piece of  Software/Arduino code.