### PR TITLE
Update Upgrading.md

### DIFF
--- a/Upgrading.md
+++ b/Upgrading.md
@@ -35,7 +35,7 @@ python -m http.server 8000
 ```
 Change your OtaUrl to http://ipoftheserver:8000/yourbinary.bin and start the upgrade process. Note: do not use `/`, `-`, or `.` characters in the name of `yourbinary`.
 
-If your binary build (yourbinary.bin) is larger than the available free flash program space, Tasmota will need to first install the minimal version of Tasmota to make more space. To have this work via the web server OTA process, you have to copy the file `tasmota-minimal.bin` in the same folder where `OTAURL` for `yourbinary.bin` is placed.
+If your binary build (yourbinary.bin) is larger than the available free flash program space, Tasmota will need to first install the minimal version of Tasmota to make more space. To have this work via the web server OTA process, you have to copy the file `tasmota-minimal.bin` in the same folder where `OTAURL` for `yourbinary.bin` is placed, and rename `tasmota-minimal.bin` to `yourbinary-minimal.bin`.
 
 ### By File Upload
 This process requires you to have a minimal build `tasmota-minimal.bin` of the firmware since the upload process needs the space in flash memory to upload the new binary. 


### PR DESCRIPTION
Following my previous PullRequest and tested on my side today and by  @blakadder too (see
https://github.com/tasmota/docs/pull/53/files/cca8d469239c7e8a8a1348ed07445febcfe715d6#diff-653d5e654c59395bc5e372f752c348f6
) the mininimal tasmota file on custom OtaUrl SHOULD BE NAME: yourbinary-minimal.bin (if NOT the OTA Process fail). Can be a copy/paste/rename of the original tasmota-minimal.bin, but with yourbinary-minimal.bin name.