### PR TITLE
Remove unsupported rules

### DIFF
--- a/Blinds-and-Shutters.md
+++ b/Blinds-and-Shutters.md
@@ -189,7 +189,6 @@ If using a Sonoff Dual R2, use the following Template:
 ### Rules
 Tasmota rule triggers:  
 - `Shutter<x>#Position`
-- `Shutter<x>#Open` and `Shutter<x>#Close`
 - `Shutter#Moving` is triggered every second if the shutter is moving
 - `Shutter#Moved` is triggered ONCE after the shutter stopped
 


### PR DESCRIPTION
Shutter<x>#Open` and `Shutter<x>#Close` are not working and I also see no such pice of code. Anyhow, same rule triggers can be easily made with Shutter<x>#Position'=100 and Shutter<x>#Position'=0 which is working fine.