### PR TITLE
Update Scripting-Language.md

### DIFF
--- a/Scripting-Language.md
+++ b/Scripting-Language.md
@@ -375,8 +375,8 @@ Enabling this feature also enables [Tasmota TLS](TLS) as `sendmail` uses SSL.
 ```
 sendmail [smtp.gmail.com:465:user:passwd:sender@gmail.com:<rec@gmail.com>:alarm] %string%
 ```  
-Remark: 
-A number of e-mail servers (like gmail) require the receiver address to be between <> as in above example. Most other e-mail servers accept this format also.
+Remark:  
+A number of e-mail servers (such as Gmail) require the receiver's e-mail address to be enclosed by `< ... >` as in example above. Most other e-mail servers also accept this format.  
 
 The following parameters can be specified during compilation via `#define` directives in `user_config_override.h`:  
 * `EMAIL_SERVER`  
@@ -386,7 +386,7 @@ The following parameters can be specified during compilation via `#define` direc
 * `EMAIL_FROM`  
 
 To use any of these values, pass an `*` as its corresponding argument placeholder.  
-> [!EXAMPLE] `sendmail [*:*:*:*:*:rec@gmail.com:theSubject] theMessage`  
+> [!EXAMPLE] `sendmail [*:*:*:*:*:<rec@gmail.com>:theSubject] theMessage`  
 
 Instead of passing the `msg` as a string constant, the body of the e-mail message may also be composed using the script `>m` _(note lower case)_ section. The specified text in this script section must end with an `#` character. `sendmail` will use the `>m` section if `*` is passed as the `msg` parameter. See [Scripting Cookbook Example].(Script-Cookbook#Send-e-mail)  
  

--- a/Scripting-Language.md
+++ b/Scripting-Language.md
@@ -373,8 +373,10 @@ Enabling this feature also enables [Tasmota TLS](TLS) as `sendmail` uses SSL.
 
 > [!EXAMPLE]  
 ```
-sendmail [smtp.gmail.com:465:user:passwd:sender@gmail.com:rec@gmail.com:alarm] %string%
+sendmail [smtp.gmail.com:465:user:passwd:sender@gmail.com:<rec@gmail.com>:alarm] %string%
 ```  
+Remark: 
+A number of e-mail servers (like gmail) require the receiver address to be between <> as in above example. Most other e-mail servers accept this format also.
 
 The following parameters can be specified during compilation via `#define` directives in `user_config_override.h`:  
 * `EMAIL_SERVER`  


### PR DESCRIPTION
I propose to change the example and ad a comment to the sendmail section.
I found the example not working giving me "Wrong Parameter" status when using smtp.gemail.com. My own e-mail server (on Synology) accepted this format  Further investigations I found that smtp.gmail,com will need the reciever adres to be between <>.  Most other servers accept this format also. Some servers (not gmail!) accept also a friendly name in the receiver adress format: FriendlyName<rec@somemail.com> but I think that this extra comment is not needed.

> [!EXAMPLE]  
```
sendmail [smtp.gmail.com:465:user:passwd:sender@gmail.com:<rec@gmail.com>:alarm] %string%
```  
Note: 
A number of e-mail servers (like gmail) require the receiver address to be between <> as in above example. Most other e-mail servers accept this format also.