### PR TITLE
adding section about unsecured fallback wifi and how to disable it

### DIFF
--- a/Securing-your-IoT-from-hacking.md
+++ b/Securing-your-IoT-from-hacking.md
@@ -125,3 +125,8 @@ How to generate the certificates in mosquitto please look at:
 ## SSL/TLS on Tasmota
 
 [TLS](TLS) article explains how to set it up in Tasmota
+
+## Disable unsecured fallback WiFi (WifiManager)
+
+In case your Wifi SSID is not available (i.e. access point dies), the WiFiManager will jump into action and make your tasmota devices available using an unsecured access point.
+Type WifiConfig into the tasmota console. If this parameter is set to 2, you might want to change it after completing the setup of your device. Some less risky options would be: 0/4/5. (For details, see https://tasmota.github.io/docs/#/Commands?id=wi-fi)


### PR DESCRIPTION
By default, my tasmota devices were configured to open the access point unsecured (my wifi router died). I did not see any information that this will persist after providing a wifi ssid in the config.
My assumption was, that the open access point was only a thing if no ssid is configured.
If this had happened while i was on vacation, everyone could have turned appliances in my house on/off. (i.e. freezer)