### PR TITLE
Update PIR-Motion-Sensors.md (404)

### DIFF
--- a/peripherals/PIR-Motion-Sensors.md
+++ b/peripherals/PIR-Motion-Sensors.md
@@ -44,7 +44,7 @@ Rule1 on Switch1#state=1 do Backlog Publish stat/%topic%/PIR1 ON; RuleTimer1 30 
 ```
 With this it will stay ON for 30 seconds then send OFF message and the timer restarts every time there's an ON trigger.
 
-Another use case as a [hand wave switch](Project-AM312-and-Sonoff-R2.md).
+Another use case as a [hand wave switch](peripherals/Project-AM312-and-Sonoff-R2).
 
 ## HC-SR501
 


### PR DESCRIPTION
Fixing 404
Assuming that links without .md is the primary crosslink format, as it is by far the most common.