### PR TITLE
Updated HEX value for IRrecv rule

### DIFF
--- a/Rule-Cookbook.md
+++ b/Rule-Cookbook.md
@@ -1385,7 +1385,7 @@ ELSE  // ENERGY#Power changed (i.e. LE 5)
 
 Using one IR receiver and one sender (or both extender) you can simply forward signals from one to another using the following rule
 ```console
-rule1 on IRreceived#Data do publish cmnd/irsideboard/irsend {Protocol:NEC,Bits:32,Data:0x%value%} endon
+rule1 on IRreceived#Data do publish cmnd/irsideboard/irsend {Protocol:NEC,Bits:32,Data:%value%} endon
 ```
 
 [Back To Top](#top)


### PR DESCRIPTION
The rule had a duplicated 0x in the prefix which resulted in invalid codes.  

Result before modification: 
```
21:04:16 RUL: IRRECEIVED#DATA performs "publish cmnd/tasmota-irsend/irsend {Protocol:NEC,Bits:32,Data:0x0X20DF10EF}"
21:04:16 MQT: cmnd/tasmota-irsend/irsend = {Protocol:NEC,Bits:32,Data:0x0X20DF10EF}
```

Result after modification: 
```
21:06:34 RUL: IRRECEIVED#DATA performs "publish cmnd/tasmota-irsend/irsend {Protocol:NEC,Bits:32,Data:0X20DF10EF}"
21:06:34 MQT: cmnd/tasmota-irsend/irsend = {Protocol:NEC,Bits:32,Data:0X20DF10EF}
```