### PR TITLE
Zigbee: CC2531-based devices *can* be used with Tasmota.

### DIFF
--- a/docs/CC2530.md
+++ b/docs/CC2530.md
@@ -8,6 +8,6 @@ Complete setup of a CC2530 module is covered in the [Zigbee article](/Zigbee)
 List of fully compatible CC2530 boards is [maintained here](https://zigbee.blakadder.com/zigbee2tasmota.html)
 
 
-!!! warning
-    You cannot use an CC2531 based device with Tasmota! CC2531 supports USB communication and not serial communication required by Zigbee2Tasmota.
+!!! info
+    You can use a CC2531 with Tasmota but _not in USB mode_! It can be flashed with CC2530 firmware and work in serial mode.
 

--- a/docs/CC2530.md
+++ b/docs/CC2530.md
@@ -9,5 +9,5 @@ List of fully compatible CC2530 boards is [maintained here](https://zigbee.blaka
 
 
 !!! info
-    You can potentially use a CC2531 with Tasmota but **not in USB mode!** Flash it with CC2530 firmware and it will work in serial mode.
+    You can potentially use a CC2531 with Tasmota but **not in USB mode!** Flash it with CC2530 firmware and it will work in serial mode. You will have to wire it for serial communication using TX and RX pins, USB port cannot be used for communicating with the CC2531 chip.
 

--- a/docs/CC2530.md
+++ b/docs/CC2530.md
@@ -9,5 +9,5 @@ List of fully compatible CC2530 boards is [maintained here](https://zigbee.blaka
 
 
 !!! info
-    You can use a CC2531 with Tasmota but _not in USB mode_! It can be flashed with CC2530 firmware and work in serial mode.
+    You can potentially use a CC2531 with Tasmota but **not in USB mode!** Flash it with CC2530 firmware and it will work in serial mode.
 

--- a/docs/Zigbee.md
+++ b/docs/Zigbee.md
@@ -23,8 +23,9 @@ Before using Zigbee to Tasmota, you need to understand a few concepts. Here is a
 #### CC2530 Zigbee Adapter
 Any TI CC2530 chip based module can serve as a coordinator. See [list of supported modules](https://zigbee.blakadder.com/zigbee2tasmota.html) with their pinouts and flashing instructions. 
 
-!!! failure "You cannot use any CC2531 based device with Tasmota!"
-    CC2531 supports USB communication and not serial communication required by Zigbee2Tasmota.
+!!! info "Devices based on CC2531 _can_ be used with Tasmota but _not in USB mode_!"
+    Normally CC2531 supports USB communication, but Zigbee2Tasmota requires serial communication.
+    When CC2530 firmware is flashed onto a CC2531, the CC2531 can be wired up for serial serial communication as described below.
 
 These PCB make all the connections required to flash the CC2530 and to run Z2T.  
 


### PR DESCRIPTION
It turns out a CC2531-based device can work in serial mode -- when it is flashed with CC2530 firmware.
This is based on my hands-on attempt.

I'm trying to get the firmware maintainers to comment on and/or document this fact in Koenkk/Z-Stack-firmware#152.