### PR TITLE
Update Zigbee.md to fix #include error

### DIFF
--- a/docs/Zigbee.md
+++ b/docs/Zigbee.md
@@ -89,7 +89,7 @@ Once the CC2530 flashing process completes, you can re-use the  ESP82xx and flas
 
 To use it you must [compile your build](Compile-your-build). Add the following to `user_config_override.h`:
 ```arduino
-#define ZIGBEE 
+#define USE_ZIGBEE 
 ```
 #### Optional 
 Run the ESP at 160MHz instead of 80MHz which ensures higher reliability in serial communication with CC2530.


### PR DESCRIPTION
In attempting to build a zigbee2tasmota node I have found that the required define to include the Zigbee code is '#define USE_ZIGBEE' and not '#define ZIGBEE' as stated in the docs.