### PR TITLE
Link to instruction how to build for 512K device

### DIFF
--- a/docs/Compile-your-build.md
+++ b/docs/Compile-your-build.md
@@ -106,3 +106,4 @@ Save file, compile the custom binary and flash it
 
 !!! note
     There are limits to how many features can be included! If you go overboard code might not compile due to features conflicting _or_ might not be able to be flashed if it exceeds [ESP8266 limits](Sensor-API#keeping-esp8266-code-compact).
+There is [`usefull comment`](https://github.com/arendst/Tasmota/issues/7365#issuecomment-623111662) on how to build Tasmota to run with old 512K flash device.


### PR DESCRIPTION
There is instruction on how to successfully build and run Tasmota on 512K device (with WEB interface and minimal modules).