### PR TITLE
Update PCA9685.md (Loose anchor)

### DIFF
--- a/docs/PCA9685.md
+++ b/docs/PCA9685.md
@@ -30,7 +30,7 @@ For information on how to set up a development environment please check the wiki
 
 Note that the I<sup>2</sup>C selection must correspond with how you have wired the module or chip as incorrect addressing will result in the PCA9685 not being detected. The valid I<sup>2</sup>C address range is 0x40 through 0x47 for the PCA9685 and most off-the-shelf modules would likely default to 0x40.
 
-If you are unsure please use [`I2Cscan`](Commands.md#I2Cscan) from Tasmota console to scan for devices on the I<sup>2</sup>C bus and you should find a device within the mentioned range.
+If you are unsure please use [`I2CScan`](Commands.md#i2cscan) from Tasmota console to scan for devices on the I<sup>2</sup>C bus and you should find a device within the mentioned range.
 
 You may also get a discovery on 0x70 but please do not use this address as it is a broadcast address and the driver does not currently support its implementation.
 


### PR DESCRIPTION
Anchor is in lower case. Link text same camel case as in Tasmota itself.