### PR TITLE
Change ZIGBEE definition in source code

### DIFF
--- a/docs/Zigbee.md
+++ b/docs/Zigbee.md
@@ -86,7 +86,7 @@ Once the flashing process completes, you can re-use the ESP82xx and flash Tasmot
 
 To use it you must [compile your build](Compile-your-build). Add the following to `user_config_override.h`:
 ```arduino
-#define ZIGBEE 
+#define USE_ZIGBEE 
 ```
 #### Optional 
 Run the ESP at 160MHz instead of 80MHz which ensures higher reliability in serial communication with CC2530.


### PR DESCRIPTION
If you look on the source code, the definitions expect USE_ZIGBEE header instead of just ZIGBEE.
Example: https://github.com/arendst/Tasmota/blob/584ed65c8c8ba2b3c74e93f2e316e6c6d06e7719/tasmota/xdrv_23_zigbee_1_headers.ino#L20