### PR TITLE
Link update: Sonoff iFan03 to iFan02

### DIFF
--- a/docs/devices/Sonoff-iFan03.md
+++ b/docs/devices/Sonoff-iFan03.md
@@ -1,4 +1,4 @@
-(For information on the iFan02 please see here - [iFan02](/docs/devices/Sonoff-iFan02.md))
+(For information on the iFan02 please see here - [iFan02](devices/Sonoff-iFan02.md))
 
 ## Serial Flashing
 Please see the [Hardware Preparation](../Getting-Started#hardware-preparation) page for general instructions.

--- a/docs/devices/Sonoff-iFan03.md
+++ b/docs/devices/Sonoff-iFan03.md
@@ -1,4 +1,4 @@
-(For information on the iFan02 please see here - [iFan02](/devices/Sonoff-iFan02))
+(For information on the iFan02 please see here - [iFan02](/docs/devices/Sonoff-iFan02.md))
 
 ## Serial Flashing
 Please see the [Hardware Preparation](../Getting-Started#hardware-preparation) page for general instructions.


### PR DESCRIPTION
I'm not entirely sure how the link is rendered out onto the web page, but at least this way it's consistent in GitHub.