### PR TITLE
Update link text and use consistent links

### DIFF
--- a/docs/DS18x20.md
+++ b/docs/DS18x20.md
@@ -1,6 +1,6 @@
 # DS18x20 temperature sensor
 
-DS18x20 driver supports [DS](https://www.maximintegrated.com/en/DS18B20)18B20, [DS18S20](https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf) and [DS1822](https://www.maximintegrated.com/en/DS1822) 1-Wire digital temperature sensors.
+DS18x20 driver supports [DS18B20](https://www.maximintegrated.com/en/products/sensors/DS18B20.html), [DS18S20](https://www.maximintegrated.com/en/products/sensors/DS18S20.html) and [DS1822](https://www.maximintegrated.com/en/products/sensors/DS1822.html) 1-Wire digital temperature sensors.
 
 ## Configuration
 


### PR DESCRIPTION
The 'DS18S20' was pointing to a PDF for the wrong sensor.