### PR TITLE
Rework openHAB tutorial

### DIFF
--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -48,7 +48,7 @@ Bridge mqtt:broker:myMQTTBroker [ host="IPofBroker", secure=false, username="myU
 Switch Switch_TH "Switch_TH"  { channel="mqtt:topic:myMQTTBroker:tasmota_TH_Thing:PowerSwitch" }
 
 String  Switch_TH_Temperatur "Temperatur [%s °C]" <temperature> {channel="mqtt:topic:myMQTTBroker:tasmota_TH_Thing:Temperature"}
-String  Sonoff_Version "Tasmota Version: [%s]" <tasmota_basic> { channel="mqtt:topic:myMQTTBroker:tasmota_6_Thing:Version"}
+String  Tasmota_Version "Tasmota Version: [%s]" <tasmota_basic> { channel="mqtt:topic:myMQTTBroker:tasmota_TH_Thing:Version"}
 ```
 
 **.rules File for the Maintenance Action:**
@@ -56,9 +56,9 @@ String  Sonoff_Version "Tasmota Version: [%s]" <tasmota_basic> { channel="mqtt:t
 ```js
 // Work with a list of selected Tasmota modules
 val tasmota_device_ids = newArrayList(
-    "tasmota-A00EEA",
+    "Tasmota_A00EEA",
     //… add all your modules here!
-    "tasmota-E8A6E4"
+    "Tasmota_E8A6E4"
 )
 // OR
 // Work with the grouptopic, addressing ALL modules at once
@@ -66,7 +66,7 @@ val tasmota_device_ids = newArrayList(
 
 rule "TasmotaMaintenance"
 when
-    Item Sonoff_Action received command
+    Item Tasmota_Action received command
 then
     logInfo("tasmota.rules", "TasmotaMaintenance on all devices: " + receivedCommand)
     val actionsBroker = getActions("mqtt","mqtt:broker:MyMQTTBroker") // change to your broker name!
@@ -82,7 +82,7 @@ then
             }
         }
     }
-    Sonoff_Action.postUpdate(NULL)
+    Tasmota_Action.postUpdate(NULL)
 end
 ```
 
@@ -198,21 +198,24 @@ The example below includes upgrading the firmware of all devices. A shoutout to 
 ![Tasmota Maintenance Actions](https://community-openhab-org.s3-eu-central-1.amazonaws.com/original/2X/9/97f0bdf6a81ffe94068e596804adf94839a5580b.png)
 
 **tasmota.items:**
+
 ```js
 //... all the above
 
 //Maintenance
-String  Sonoff_Action "Tasmota Action" <tasmota_basic>
+String  Tasmota_Action "Tasmota Action" <tasmota_basic>
 ```
 
 **yourhome.sitemap:**
+
 ```js
 //...
-Switch item=Sonoff_Action mappings=[restart="Restart", queryFW="Query FW", upgrade="Upgrade FW"]
+Switch item=Tasmota_Action mappings=[restart="Restart", queryFW="Query FW", upgrade="Upgrade FW"]
 //...
 ```
 
 **tasmota.rules:**
+
 ```js
 // Work with a list of selected Tasmota modules
 val tasmota_device_ids = newArrayList(
@@ -226,7 +229,7 @@ val tasmota_device_ids = newArrayList(
 
 rule "Tasmota Maintenance"
 when
-    Item Sonoff_Action received command
+    Item Tasmota_Action received command
 then 
     logInfo("tasmota.rules", "TasmotaMaintenance on all devices: " + receivedCommand)
     for (String device_id : tasmota_device_ids) {
@@ -241,7 +244,7 @@ then
             }
         }
     }
-    Sonoff_Action.postUpdate(NULL)
+    Tasmota_Action.postUpdate(NULL)
 end
 ```
 
@@ -261,8 +264,9 @@ tasmotaRelease.updateInterval=43200000
 ```
 
 **tasmota.items:**
+
 ```js
-String Sonoff_Current_FW_Available "Current Release [%s]" <tasmota_basic> (Sonoff_Maintenance) { http="<[tasmotaRelease:10000:JSONPATH($[0].name)]"}
+String Tasmota_Current_FW_Available "Current Release [%s]" <tasmota_basic> { http="<[tasmotaRelease:10000:JSONPATH($[0].name)]"}
 ```
 
 With the item in your sitemap, you will now see the latest release/tag from the tasmota repository.

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -15,7 +15,7 @@ The screenshot of an openHAB Sitemap below features a few Sonoff modules for lig
 * MQTT broker available (e.g. Eclipse Mosquitto via [openHABian](https://www.openhab.org/docsopenhabian.html))
 * A [basic understanding of MQTT](http://www.hivemq.com/blog/mqtt-essentials) 
 * Working and tested connection between openHAB and the MQTT broker
-* (optional) Standalone [MQTT client](http://www.hivemq.com/blog/seven-best-mqtt-client-tools) (e.g. [mqtt-spy](https://kamilfb.github.io/mqtt-spy)) to observe and identify messages on the MQTT broker
+* (optional) Standalone [MQTT client](http://www.hivemq.com/blog/seven-best-mqtt-client-tools) (e.g. [MQTT Explorer](https://mqtt-explorer.com/)) to observe and identify messages on the MQTT broker
 
 **Highly recommended:** If you are new to openHAB + MQTT, go through this tutorial: <br>
 ⇨ [MQTT Binding - Getting Started 101](https://community.openhab.org/t/mqtt-binding-v1-11-getting-started-101/33958)

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -17,8 +17,6 @@ The screenshot of an openHAB Sitemap below features a few Sonoff modules for lig
 * Working and tested connection between openHAB and the MQTT broker
 * (optional) Standalone [MQTT client](http://www.hivemq.com/blog/seven-best-mqtt-client-tools) (e.g. [MQTT Explorer](https://mqtt-explorer.com/)) to observe and identify messages on the MQTT broker
 
-Before continuing, please make sure you assigned **unique MQTT "Topics"** in the Tasmota configuration interface of each pf your devices. The default MQTT topic is "tasmota", in the examples below we will use names like "tasmota-A00EEA".
-
 <!-- ![Example Tasmota MQTT settings](https://community-openhab-org.s3-eu-central-1.amazonaws.com/original/2X/8/8fe9008fb24b0b70e6eddf7cf0f0c70c8ac21b92.png "Example Tasmota MQTT settings") -->
 
 ----

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -239,7 +239,7 @@ then
             case "queryFW" :
                 publish("broker", "cmnd/" + device_id + "/status", "2")
             case "upgrade" : {
-                publish("broker", "cmnd/" + device_id + "/otaurl", "http://ota.tasmota.com/tasmota/tasmota.bin")
+                publish("broker", "cmnd/" + device_id + "/otaurl", "http://ota.tasmota.com/tasmota/release/tasmota.bin")
                 publish("broker", "cmnd/" + device_id + "/upgrade", "1")
             }
         }

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -1,7 +1,7 @@
 
-The "open Home Automation Bus" ([openHAB](http://www.openhab.org/)) is an open source, technology agnostic home automation platform which runs as the center of your smart home. Besides 200 other add-ons for all kinds of technologies, openHAB provides an MQTT add-on ("binding") to interface with systems like Tasmota.
+The "open Home Automation Bus" ([openHAB](http://www.openhab.org/)) is an open source, technology agnostic home automation platform which runs as the center of your smart home. Besides more than 400 other add-ons for all kinds of technologies, openHAB provides an MQTT add-on ("binding") to interface with systems like Tasmota.
 
-By following the guide below you'll be able to observe, control and manage your Tasmotamodules from your openHAB system. If you are new to openHAB, please learn about the basic concepts and the initial setup. The below article will not cover any basics which are out of scope to the Tasmota integration.
+By following the guide below you'll be able to observe, control and manage your Tasmota modules from your openHAB system. If you are new to openHAB, please learn about the basic concepts and the initial setup. The below article will not cover any basics which are out of scope to the Tasmota integration.
 
 **Example Result:**
 The screenshot of an openHAB Sitemap below features a few Sonoff modules for lighting, two modified Sonoff Basic with sensors for temperature and humidity readings and two Sonoff Pow for power measurements of a washing machine and dishwasher:
@@ -10,7 +10,7 @@ The screenshot of an openHAB Sitemap below features a few Sonoff modules for lig
 
 ## Requirements
 
-* Working openHAB installation (https://www.openhab.org/docs/)
+* Working openHAB installation ([see documentation](https://www.openhab.org/docs/))
 * Configured Tasmota device (accessible from your local network)
 * MQTT broker available (e.g. Eclipse Mosquitto via [openHABian](https://www.openhab.org/docsopenhabian.html))
 * A [basic understanding of MQTT](http://www.hivemq.com/blog/mqtt-essentials) 
@@ -181,17 +181,18 @@ then
 end
 ```
 
-#### Comparing your device firmware with the current Tasmota GitHub Release
+### Comparing your device firmware with the current Tasmota GitHub Release
 
 Knowing your devices firmware version(s) is good.
 Being able to compare it with the current release directly, is even better.
-You can archive this by combining the maintenance actions with the openHAB http binding, the jsonpath transformation and the GitHub API.
+You can archive this by combining the maintenance actions with the openHAB http binding, the JsonPath transformation and the GitHub API.
 
 Just extend the maintenance setup with the following Item and config:
 
 **http.cfg:**
+
 ```js
-# Tasmota Release Status (cached twice a day)
+# Tasmota Release Version (cached twice a day)
 tasmotaRelease.url=https://api.github.com/repos/arendst/Tasmota/tags
 tasmotaRelease.updateInterval=43200000
 ```
@@ -206,7 +207,7 @@ With this item in your sitemap, you will now see the latest release/tag from Tas
 
 ## Discovering Interesting Topics
 
-Additional or further interesting topics are easily identified by reading up on the Tasmota wiki and by subscribing to the modules topics. Subscribe to all topics of one module with the [MQTT wildcard](http://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices) topic string `+/tasmota_XYZ/#` (String depends on your user-configured Topic/FullTopic). Configure items for the identified topics similar to the ones below.
+Additional or further interesting topics are easily identified by reading up on the Tasmota wiki and by subscribing to the modules topics. Subscribe to all topics of one module using [MQTT wildcard](http://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices) topic string `+/tasmota_XYZ/#` (string depends on your user-configured Topic/FullTopic). Configure items for the identified topics similar to the ones below.
 
 **Example:**
 MQTT messages published by a Sonoff Pow module are shown below (using [mosquitto_sub](https://mosquitto.org/man/mosquitto_sub-1.html)).

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -24,7 +24,7 @@ If not done yet, you first need to **install and activate** the [MQTT](https://w
 ----
 
 !!! info "MQTTv1 vs. MQTTv2 Binding Information"
-    Please note that since `mqtt1` is a legacy binding for years now, it will no longer receive updates or fixes. See [older version of this tutorial](https://github.com/tasmota/docs/blob/4c7240ddd5d81146ea148f471b1544283e655ec3/docs/openHAB.md#mqttv1-integration) on how to integrate Tasmota using this binding if you are using `mqtt1` - but be advised that it's not recommended anymore, it's better to upgrade to MQTTv2 binding.
+    Please note that since `mqtt1` is a legacy binding for years now, it will no longer receive updates or fixes. See [older version of this tutorial](https://github.com/tasmota/docs/blob/4c7240ddd5d81146ea148f471b1544283e655ec3/docs/openHAB.md#mqttv1-integration) on how to integrate Tasmota using this binding if you are using `mqtt1` - but be advised that it's not recommended anymore, it's better to upgrade to MQTTv2 binding. See [openHAB announcement of MQTTv2 for details](https://www.openhab.org/blog/2018-12-16-mqtt-arrives-in-the-modern-openhab-2-x-architecture.html) on how to change your configuration.
 
 ## MQTTv2 Integration
 

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -17,8 +17,6 @@ The screenshot of an openHAB Sitemap below features a few Sonoff modules for lig
 * Working and tested connection between openHAB and the MQTT broker
 * (optional) Standalone [MQTT client](http://www.hivemq.com/blog/seven-best-mqtt-client-tools) (e.g. [MQTT Explorer](https://mqtt-explorer.com/)) to observe and identify messages on the MQTT broker
 
-<!-- ![Example Tasmota MQTT settings](https://community-openhab-org.s3-eu-central-1.amazonaws.com/original/2X/8/8fe9008fb24b0b70e6eddf7cf0f0c70c8ac21b92.png "Example Tasmota MQTT settings") -->
-
 ----
 
 If not done yet, you first need to **install and activate** the [MQTTv1](https://www.openhab.org/addons/bindings/mqtt1/)/[MQTTv2](https://www.openhab.org/addons/bindings/mqtt/)&ast;, the [MQTT action](https://www.openhab.org/addons/actions/mqtt/) and the [JsonPath transformation](https://www.openhab.org/addons/transformations/jsonpath/), e.g. via the openHAB Paper UI Add-ons section.

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -19,7 +19,7 @@ The screenshot of an openHAB Sitemap below features a few Sonoff modules for lig
 
 ----
 
-If not done yet, you first need to **install and activate** the [MQTTv1](https://www.openhab.org/addons/bindings/mqtt1/)/[MQTTv2](https://www.openhab.org/addons/bindings/mqtt/)&ast;, the [MQTT action](https://www.openhab.org/addons/actions/mqtt/) and the [JsonPath transformation](https://www.openhab.org/addons/transformations/jsonpath/), e.g. via the openHAB Paper UI Add-ons section.
+If not done yet, you first need to **install and activate** the [MQTT](https://www.openhab.org/addons/bindings/mqtt/) binding, the [MQTT action](https://www.openhab.org/addons/actions/mqtt/) and the [JsonPath transformation](https://www.openhab.org/addons/transformations/jsonpath/), e.g. via the openHAB Paper UI Add-ons section.
 
 ****
 

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -17,9 +17,6 @@ The screenshot of an openHAB Sitemap below features a few Sonoff modules for lig
 * Working and tested connection between openHAB and the MQTT broker
 * (optional) Standalone [MQTT client](http://www.hivemq.com/blog/seven-best-mqtt-client-tools) (e.g. [MQTT Explorer](https://mqtt-explorer.com/)) to observe and identify messages on the MQTT broker
 
-**Highly recommended:** If you are new to openHAB + MQTT, go through this tutorial: <br>
-⇨ [MQTT Binding - Getting Started 101](https://community.openhab.org/t/mqtt-binding-v1-11-getting-started-101/33958)
-
 Before continuing, please make sure you assigned **unique MQTT "Topics"** in the Tasmota configuration interface of each pf your devices. The default MQTT topic is "tasmota", in the examples below we will use names like "tasmota-A00EEA".
 
 <!-- ![Example Tasmota MQTT settings](https://community-openhab-org.s3-eu-central-1.amazonaws.com/original/2X/8/8fe9008fb24b0b70e6eddf7cf0f0c70c8ac21b92.png "Example Tasmota MQTT settings") -->

--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -24,7 +24,7 @@ If not done yet, you first need to **install and activate** the [MQTT](https://w
 ****
 
 !!! info "MQTTv1 vs. MQTTv2 Binding Information"
-    The openHAB community has released a new native openHAB 2 MQTT Binding, which complies with enhancements and significantly changes. Be aware that if you update your openHAB instance, the new MQTT binding may be get installed and `mqtt1` could be uninstalled! This means that any MQTT openHAB automations in your openHAB environment will exhibit odd behavior or not operate at all. If you are using `mqtt1`, jump to the `mqtt1` section [below](#mqttv1-integration).
+    Please note that since `mqtt1` is a legacy binding for years now, it will no longer receive updates or fixes. See [older version of this tutorial](https://github.com/tasmota/docs/blob/4c7240ddd5d81146ea148f471b1544283e655ec3/docs/openHAB.md#mqttv1-integration) on how to integrate Tasmota using this binding if you are using `mqtt1` - but be advised that it's not recommended anymore, it's better to upgrade to MQTTv2 binding.
 
 ## MQTTv2 Integration
 


### PR DESCRIPTION
I reworked openHAB tutorial to only reflect MQTTv2 binding ([released about two years ago](https://www.openhab.org/blog/2018-12-16-mqtt-arrives-in-the-modern-openhab-2-x-architecture.html)) - one really should start using that, it's out long enough and even openHAB 3 being on its way. Old MQTTv1 tutorial still linked for references, but it's really not recommended to use it (and both bindings can be run in parallel, just in case).

I'm unsure if indenting for code examples is good this way, I thought it might help reading it.

See individual commits for details on what I have done - I suggest not doing a fast-forward merge. I only did (maybe) atomic commits to structure what I did and make a review easier.