### PR TITLE
Update Zigbee.md with more generic EZSP description

### DIFF
--- a/docs/Zigbee.md
+++ b/docs/Zigbee.md
@@ -3,14 +3,14 @@
 Zigbee2Tasmota (Z2T) is a lightweight Zigbee solution running on an ESP82xx Wi-Fi chip. Hence it is easier to deploy wherever you want in your home. It is largely inspired by [Zigbee2mqtt](https://www.zigbee2mqtt.io/) but it's a complete rewrite to make it fit on an ESP82xx with 80kB of RAM and only 1MB of flash memory.
 
 ## Hardware
-This integration works with [Sonoff ZbBridge](https://zigbee.blakadder.com/Sonoff_ZBBridge.html) and any Texas Instruments [CC2530x](CC2530.md) chip based device. A complete list of compatible coordinators and Zigbee devices compatible with Z2T is in the [Zigbee Device Compatibility Repository](https://zigbee.blakadder.com/zigbee2tasmota.html). 
+This integration works with any Texas Instruments [CC2530](CC2530.md) chip based device as well as with Silicon Labs EFR32 chip based devices like [Sonoff ZBBridge](https://zigbee.blakadder.com/Sonoff_ZBBridge.html). A complete list of compatible Zigbee coordinators and Zigbee devices compatible with Z2T is in the [Zigbee Device Compatibility Repository](https://zigbee.blakadder.com/zigbee2tasmota.html). 
 
-While initially designed for CC253x (Z-Stack firmware), the appearance of Sonoff ZbBridge required using a different protocol (EZSP). Once the coordinator is started and communicates with Tasmota, the end result is the same and there is no difference in their operation.
+While Z2T was initially designed for Texas Instruments Z-Stack firmware and protocol for CC253x based device, since then support for Silicon Labs EZSP (EmberZNet Serial Protocol) firmware has also been added. Once the Zigbee coordinator is started and communicates with Tasmota, the end result is the same and there is no difference in their operation.
 
 Flashing and installation instructions for:
 
-- [Sonoff ZbBridge](https://zigbee.blakadder.com/Sonoff_ZBBridge.html)
-- [CC2530x](CC2530.md) based devices
+- [Sonoff ZBBridge by ITead](https://zigbee.blakadder.com/Sonoff_ZBBridge.html)
+- [CC2530 based devices](CC2530.md)
 
 ## Introduction
 Before using Zigbee with Tasmota, you need to understand a few concepts. Here is a simplified comparison to the Wi-Fi equivalent (sort of).


### PR DESCRIPTION
Update Zigbee.md with more generic EZSP description as the support is not really limited to Sonoff ZBBridge as one can setup a DIY bridge with an ESP8266 and a Silicon Labs EFR32 Series 1 or Series 2 based module, such as for example the IKEA TRÅDFRI ICC-A-1 Module from IKEA Tradfri devices, as per the https://github.com/MattWestb/IKEA-TRADFRI-ICC-A-1-Module guide by @MattWestb