### PR TITLE
Update Sonoff-4CH-Pro.md

### DIFF
--- a/docs/devices/Sonoff-4CH-Pro.md
+++ b/docs/devices/Sonoff-4CH-Pro.md
@@ -62,3 +62,11 @@ Changing these switches for operations like inching and interlocking are also su
 * [Itead Product Page](http://sonoff.itead.cc/en/products/sonoff/sonoff-4ch-pro)
 * [Itead Shop](https://www.itead.cc/sonoff-4ch-pro.html)
 * [Itead Wiki](https://www.itead.cc/wiki/Sonoff_4CH_Pro)
+
+
+WARNING
+The Sonoff CH4 PRO is subject to radio frequency disturbances with random activation of the buttons. 
+To eliminate interference due to the U7 (SYN470RU7 RF-433  module) you can cut the wire between U7 and U8 (MCU STM32f030c6). This line starts from pin 10 of U7, the part towards MCU can be soldered to ground (surrounding area). It is also possible to set the RF module (U7) in shutdown-mode by unsoldering or cutting pin 11.
+
+<img title="Disable RF433 interferece" src="https://github.com/forty76/ch4_pro/blob/main/Disabilitare%20RF%20ch4_pro.jpg" align="middle" />
+


### PR DESCRIPTION
I have owned the Sonoff CH4 PRO for 2 years, I immediately found random activations of the buttons. Not knowing the source of the problem I searched online for similar experiences but these attributed the problem either to electrical disturbances and it was recommended to increase buttondebounce or to MQTT retain. I have made several attempts at both hardware and software without success. In the last month after the purchase of an RF door switch I accidentally found the activation of the buttons in conjunction with the sending of the RF code. I searched online and found other similar findings. The problem is that both the buttons and the RF433 commands pass through MCU STM32 so the ESP8285 receives the button activation signal, not knowing if it originated from a physical button or RF command, the Tasmota console shows “APP: Button1 level 1-0”.
After change I tested the device for 1 week and found the complete resolution of random button activation issues.
I think it is useful to inform in advance through this document those who are about to program Sonoff CH4 PRO with tasmota, simplifying the resolution of the problem. Especially since without targeted research online information is misleading.