### PR TITLE
Update PIR-Motion-Sensors.md

### DIFF
--- a/docs/PIR-Motion-Sensors.md
+++ b/docs/PIR-Motion-Sensors.md
@@ -40,7 +40,8 @@ Pin marked VOUT is connected to a free GPIO pin on the device.
 
 This PIR goes to off state after a few seconds so we need to use this rule *instead* of the one in the example. 
 ```console
-Rule1 on Switch1#state=1 do Backlog Publish stat/%topic%/PIR1 ON; RuleTimer1 30 endon on Rules#Timer=1 do Publish stat/%topic%/PIR1 OFF endon
+SwitchMode1 14
+Rule1 on Switch1#state=1 do Backlog Publish stat/%topic%/PIR1 ON; Power1 ON; RuleTimer1 30 endon on Rules#Timer=1 do Backlog Publish stat/%topic%/PIR1 OFF; Power1 OFF endon
 ```
 With this it will stay ON for 30 seconds then send OFF message and the timer restarts every time there's an ON trigger.
 


### PR DESCRIPTION
Done a lot of testing with a AM312 and WS2812.
`SwitchMode1 1` toggles off the Light after around 4sec and if I understand right, this should not be the case.

`SwitchMode1 14` and `SwitchMode1 15` doesn't toggle on the Light, so I added `Power1 ON` to the Rule.


Tested with Tasmota 9.1.0.1