### PR TITLE
Fix markup and a typo in one sentence

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -296,7 +296,7 @@ When the `<if-statement>` directly follows the trigger the standard 'Do' syntax 
   `Rule1 ON Power1#State DO IF (%value%==1) Backlog Power2 1;Power3 1 ENDIF ENDON` is **permitted**
   `Rule1 ON Power1#State DO IF (%value%==1) Power2 1;Power3 1 ENDIF ENDON` is also **permitted**
 
-When the `<if-statement>` is preceded by other Tasmota commands you should use `Backlog' rather thab 'Do' , e.g.  
+When the `<if-statement>` is preceded by other Tasmota commands you should use `Backlog` rather than `Do` , e.g.  
   `Rule1 ON ENERGY#Current>10 Backlog Power1 0; IF (%var1%==1) Power1 1 ENDIF;Power 2 0;Power3 1 ENDON`
   **and not**
   `Rule1 ON ENERGY#Current>10 DO Power1 0; IF (%var1%==1) Power1 1 ENDIF ENDON`

--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -94,7 +94,8 @@ Mqtt#Connected<a id="MqttConnected"></a>|when MQTT is connected
 Mqtt#Disconnected<a id="MqttDisconnected"></a>|when MQTT is disconnected
 Power1#Boot<a id="PowerBoot"></a>|`Relay1` state before Wi-Fi and MQTT are connected and before Time sync but after `PowerOnState` is executed. Power#Boot triggers before System#Boot.<BR>This trigger's value will be the last state of `Relay1` if [`PowerOnState`](Commands.md#poweronstate) is set to its default value (`3`).
 Power1#State<a id="PowerState"></a>|when a power output is changed<br>use `Power1#state=0` and `Power1#state=1` for comparison, not =off or =on<br>Power2 for Relay2, etc.
-Rotary1#Pos1<a id="Rotary"></a>|when rotary encoder change. See [Use a rotary encoder](#use-a-rotary-encoder).Rules#Timer=1<a id="RulesTimer"></a>|when countdown `RuleTimer1` expires
+Rotary1#Pos1<a id="Rotary"></a>|when rotary encoder change. See [Use a rotary encoder](#use-a-rotary-encoder).
+Rules#Timer=1<a id="RulesTimer"></a>|when countdown `RuleTimer1` expires.
 Switch1#Boot<a id="SwitchBoot"></a>|occurs after Tasmota starts before it is initializated.
 Switch1#State<a id="SwitchState"></a>|when a switch changes to state. Will not trigger if SwitchTopic is set.<br>use `Switch1#state=0` and `Switch1#state=1` for comparison, not =off or =on<br>`0` = OFF<BR>`1` = ON<BR>`2` = TOGGLE<BR>`3` = HOLD (`SwitchTopic 0` must be set for this to trigger)<BR>`4` = INC_DEC (increment or decrement dimmer)<BR>`5` = INV (change from increment to decrement dimmer and vice versa)<BR>`6` = CLEAR (button released for the time set with `SetOption32`)
 System#Boot<a id="SystemBoot"></a>|occurs once after Tasmota is fully intialized (after the INFO1, INFO2 and INFO3 console messages). `System#Boot` triggers after Wi-Fi and MQTT (if enabled) are connected. If you need a trigger prior to every service being initialized, use `Power1#Boot`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: Documentation (Wiki) for Tasmota
 site_url: https://tasmota.github.io/docs/
 repo_name: 'arendst/tasmota'
 repo_url: 'https://github.com/arendst/tasmota'
-edit_uri: 'https://github.com/tasmota/docs/blob/development/docs/'
+edit_uri: 'https://github.com/tasmota/docs/blob/master/docs/'
 # copyright: 'Copyright &copy; 2020 Tasmota Development Team'
 
 plugins:


### PR DESCRIPTION
Fixed three single-quotes that should have been backticks which was causing the wrong parts of the sentence to be identified as code vs text.
Also corrected "thab" to "than".