### PR TITLE
Separate note about NodeMCU and D1 mini from the list of Serial-to-USB Adapter devices

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -16,7 +16,9 @@ The [power supplied to the device](https://www.letscontrolit.com/wiki/index.php?
 * [FTDI FT232](https://www.ftdichip.com/Products/ICs/FT232R.htm) - these adapters have a lot of fakes in the market so buy only from reliable sources ([example](https://www.sparkfun.com/products/13746)). Buy only the variant with a separate 3.3V regulator on PCB! 
 * [CP2102](https://www.silabs.com/documents/public/data-sheets/cp2102-9.pdf) or [PL2303](http://www.prolific.com.tw/UserFiles/files/ds_pl2303HXD_v1_4_4.pdf) - works with certain devices, but using an external 3.3V supply might be necessary. Not recommended for beginners!
 * [RaspberryPi](Flash-Sonoff-using-Raspberry-Pi) - only for advanced users. External 3.3V supply necessary.
-* [NodeMCU](https://en.wikipedia.org/wiki/NodeMCU) and [D1 mini](https://cleanuri.com/x60JQ9) (Pro/Lite) boards have a micro USB upload port and don't require an adapter.
+
+!!! note
+    [NodeMCU](https://en.wikipedia.org/wiki/NodeMCU) and [D1 mini](https://cleanuri.com/x60JQ9) (Pro/Lite) boards have a micro USB upload port and don't require an adapter.
 
 !!! note 
     Don't forget to install drivers for your serial-to-USB adapter.


### PR DESCRIPTION
The formatting makes it look like you can use NodeMCU and D1 mini to flash devices. I bought one and spent hours trying to make it work only to realise the bullet was in fact noting an exception to flashing those devices, instead of using them to do the flashing.