### PR TITLE
Added example of another temperature monitoring device

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -1758,6 +1758,7 @@ Resets checking timer if temperature is connected
 ```haskell
 Rule ON tele-SI7021#temperature DO Backlog var1 1; RuleTimer1 30; event ctrl_ready=1; event temp_demand=%value% ENDON
 ```
+use `tele-DS18B20#temperature` for the DS18B20 device. An incorrect device setting will cause polling to happen every 1-2 seconds.
 
 Thermostat control - upper limit and lower limit and enabled  
 


### PR DESCRIPTION
If the device is specified incorrectly then MQTT gets spammed with messages and things appear to be working.
By specifying the device correctly polling instead happens every 70's instead of the 1-2 seconds.