### PR TITLE
Add documentation for BLE stuff relating to BLE_ESP32 - try 2

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -303,6 +303,46 @@ WattRes<a class="cmnd" id="sensors-wattres"></a>|Power sensor resolution<BR>`0..
 WeightRes<a class="cmnd" id="weightres"></a>|Load cell sensor resolution<BR>`0..3` = maximum number of decimal places
 See also|[`SetOption8`](#setoption8)  - Show temperature in Celsius *(default)* or Fahrenheit<BR>[`SetOption18`](#setoption18) - Set status of signal light paired with CO<sub>2</sub> sensor<BR>[`SetOption24`](#setoption24) - Set pressure units
 
+### Bluetooth Low Energy - BLE
+
+Command|Parameters
+:---|:---
+BLEMode<a class="cmnd" id="blemode"></a>|Change the operational mode of the BLE driver.<BR>`BLEMode0` = disable regular BLE scans.<BR>`BLEMode1` = BLE scan on command only.<BR>`BLEMode2` = regular BLE scanning (default).
+BLEPeriod<a class="cmnd" id="bleperiod"></a>|Set the period for publish of BLE data<BR>`<value>` = set interval in seconds
+BLEScan<a class="cmnd" id="blescan"></a>|Cause/Configure BLE a scan<BR>`BLEScan0 0..1` = enable or disable Active scanning. (an active scan will gather extra data from devices, including name)<BR>`BLEScan` = Trigger a 20s scan now if in BLEMode1<BR>`BLEScan n` = Trigger a scan now for n seconds if in BLEMode1
+BLEDetails<a class="cmnd" id="bledetails"></a>|Display details about recevied adverts<BR>`BLEDetails0` = disable showing of details.<BR>`BLEDetails1 mac|alias` = show the next advert from device mac|alias<BR>`BLEDetails2 mac|alias` = show all advert from device mac|alias (some may be lost).<BR>`BLEDetails3` = show all adverts from all devices (some will be lost).
+BLEAlias<a class="cmnd" id="blealias"></a>|Set Alias names for devices.  A device may be referred to by it's alias in subsequent commands<BR>`BLEAlias mac=alias mac=alias ...` = set one or more aliases from devices.<BR>`BLEAlias2` = clear all aliases.
+BLEName<a class="cmnd" id="blename"></a>|Read or write the name of a BLE device.<BR>`BLEName mac|alias` = read the name of a device using 1800/2A00.<BR>`BLEName mac|alias` = write the name of a device using 1800/2A00 - many devices are read only.
+BLEDevices<a class="cmnd" id="bledevices"></a>|Cause a list of known devices to be sent on MQTT, or Empty the list of known devices.<BR>`BLEDevices0` = clear the known devices list.<BR>`BLEDevices` = Cause the known devices list to be published on stat/TASName/BLE.
+BLEMaxAge<a class="cmnd" id="blemaxage"></a>|Set the timeout for device adverts.<BR>`BLEMaxAge n` = set the devices timeout to n seconds.<BR>`BLEMaxAge` = display the device timeout.
+BLEOp<a class="cmnd" id="bleop"></a>|Perform a simple active BLE operation (read/write/notify).<BR>see separate description in source code
+BLEDebug<a class="cmnd" id="bledebug"></a>|Set BLE debug level.<BR>`BLEDebug` = show extra debug information<BR>`BLEDebug0` = suppress extra debug
+BLEAddrFilter<a class="cmnd" id="bleaddrfilter"></a>|Set BLE Address type filter.<BR>`BLEAddrFilter` = show filter level<BR>`BLEAddrFilter n` = set BLE address type filter 0..3 - default 3.  Ignores BLE address types > filter value.  Set 0 to ONLY see public addresses.
+
+### BLE iBeacon (ESP32)
+
+Command|Parameters
+:---|:---
+iBeacon<a class="cmnd" id="ibeacon"></a>|Show or set enable for the iBeacon driver<BR>`iBeacon` = Display 0|1<BR>`iBeacon 0` = disable<BR>`iBeacon 1` = enable.
+iBeaconOnlyAliased<a class="cmnd" id="ibeacononlyaliased"></a>|Show or set OnlyAliased for the iBeacon driver<BR>`iBeaconOnlyAliased` = Display 0|1<BR>`iBeaconOnlyAliased 0` = enable iBeacon to hear ALL BLE devices<BR>`iBeaconOnlyAliased 1` = enable iBeacon to hear ONLY devices with valid BLEAlias<BR>`iBeaconOnlyAliased 2` = enable iBeacon to hear ONLY devices with valid BLEAlias starting `iB`
+iBeaconClear<a class="cmnd" id="ibeaconclear"></a>|Clear iBeacon list
+iBeaconPeriod<a class="cmnd" id="ibeaconperiod"></a>|Display or Set the period for publish of iBeacon data<BR>`iBeaconPeriod` = display interval<BR>`iBeaconPeriod ss` = set interval in seconds
+iBeaconTimeout<a class="cmnd" id="ibeacontimeout"></a>|Display or Set the timeout for iBeacon devices<BR>`iBeaconTimeout` = display timeout<BR>`iBeaconTimeout ss` = set timeout in seconds
+
+
+### BLE MI/Xiaomi sensors (ESP32)
+
+Command|Parameters
+:---|:---
+MI32Period<a class="cmnd" id="mi32block"></a>|Display/Set the active scan and tele period for the MI32 driver.<BR>`MI32Period` = diisplay the period in seconds.<BR>`MI32Period n` = Set the MI driver active read and tele period to n seconds.
+MI32Time<a class="cmnd" id="mi32time"></a>|Set the time on a device.<BR>`MI32Time n` = set the time on the device in slot n.
+MI32Page<a class="cmnd" id="mi32page"></a>|Display/Set the sensors per page in the web view.<BR>`MI32page` = show sensors per page.<BR>`MI32page n` = Set sensors per page to n.
+MI32Battery<a class="cmnd" id="mi32battery"></a>|Trigger an active read of battery values.<BR>`MI32Battery` = request the driver read the battery from all sensors which have active battery read requirements.
+MI32Unit<a class="cmnd" id="mi32unit"></a>|Write the current Tasmota temperature unit to a sensor.<BR>`MI32Unit s` = set the Temp unit on sensor in slot s.
+MI32Key<a class="cmnd" id="mi32key"></a>|Add a decryption key.<BR>`MI32Key hexkey` = add a 44 character decryption key to the keys list.
+MI32Keys<a class="cmnd" id="mi32keys"></a>|Add one or more decryption keys by mac or alias.<BR>`MI32Keys` = list keys.<BR>`MI32Keys mac|alias=key mac|alias=key ...` = add keys for mac|alias.<BR>`MI32Keys mac|alias=` - remove keys for one mac|alias.<BR>`MI32Keys2` - remove all keys.
+MI32Block<a class="cmnd" id="mi32block"></a>|Block or unblock a sensor device.<BR>`MI32Block` = list blocked devices by mac.<BR>`MI32Block mac|alias` = Block one mac/alias.
+MI32Optionx n<a class="cmnd" id="mi32option"></a>| Set driver options at runtime<BR> x=0 - 0 -> sends only recently received sensor data, 1 -> aggregates all recent sensors data types<BR>x=1 - 0 -> shows full sensor data at TELEPERIOD, 1 -> shows no sensor data at TELEPERIOD<BR>x=2 - 0 -> sensor data only at TELEPERIOD (default and "usual" Tasmota style), 1 -> direct bridging of BLE-data to mqtt-messages<BR>x=5 - 0 -> show all relevant BLE sensors, 1 -> show only sensors with a BLEAlias<BR>x=6 (from v 9.0.2.1) 1 -> always use MQTT Topic like `tele/tasmota_ble/<name>` containing only one sensor
 ### Power Monitoring
 
 Command|Parameters

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -329,7 +329,6 @@ iBeaconClear<a class="cmnd" id="ibeaconclear"></a>|Clear iBeacon list
 iBeaconPeriod<a class="cmnd" id="ibeaconperiod"></a>|Display or Set the period for publish of iBeacon data<BR>`iBeaconPeriod` = display interval<BR>`iBeaconPeriod ss` = set interval in seconds
 iBeaconTimeout<a class="cmnd" id="ibeacontimeout"></a>|Display or Set the timeout for iBeacon devices<BR>`iBeaconTimeout` = display timeout<BR>`iBeaconTimeout ss` = set timeout in seconds
 
-
 ### BLE MI/Xiaomi sensors (ESP32)
 
 Command|Parameters
@@ -343,6 +342,7 @@ MI32Key<a class="cmnd" id="mi32key"></a>|Add a decryption key.<BR>`MI32Key hexke
 MI32Keys<a class="cmnd" id="mi32keys"></a>|Add one or more decryption keys by mac or alias.<BR>`MI32Keys` = list keys.<BR>`MI32Keys mac|alias=key mac|alias=key ...` = add keys for mac|alias.<BR>`MI32Keys mac|alias=` - remove keys for one mac|alias.<BR>`MI32Keys2` - remove all keys.
 MI32Block<a class="cmnd" id="mi32block"></a>|Block or unblock a sensor device.<BR>`MI32Block` = list blocked devices by mac.<BR>`MI32Block mac|alias` = Block one mac/alias.
 MI32Optionx n<a class="cmnd" id="mi32option"></a>| Set driver options at runtime<BR> x=0 - 0 -> sends only recently received sensor data, 1 -> aggregates all recent sensors data types<BR>x=1 - 0 -> shows full sensor data at TELEPERIOD, 1 -> shows no sensor data at TELEPERIOD<BR>x=2 - 0 -> sensor data only at TELEPERIOD (default and "usual" Tasmota style), 1 -> direct bridging of BLE-data to mqtt-messages<BR>x=5 - 0 -> show all relevant BLE sensors, 1 -> show only sensors with a BLEAlias<BR>x=6 (from v 9.0.2.1) 1 -> always use MQTT Topic like `tele/tasmota_ble/<name>` containing only one sensor
+
 ### Power Monitoring
 
 Command|Parameters

--- a/docs/HM-10.md
+++ b/docs/HM-10.md
@@ -55,7 +55,7 @@ If you have supported Bluetooth devices in range, they will soon be discovered a
     `HM10Baud 9600` (sets 9600 baud rate on Tasmota side) then `HM10AT RENEW` (reset HM10 to factory settings which should use 115200 baud rate on newer firmware)
     and reboot Tasmota. If that doesn't solve it you will have to connect to the HM-10 with serial-to-USB adapter and set the baudrate in a terminal using commands `AT+RENEW` then `AT+BAUD?`. If the output is 4 baudrate is properly set to 115200, if not use `AT+BAUD4`
 
-For a complete overview of supported devices, commands and features read the [Bluetooth article](Bluetooth#ble-sensors-using-hm-1x)
+For a complete overview of supported devices, commands and features read the [Bluetooth article](ble/Bluetooth-Esp8266#ble-sensors-using-hm-1x)
 
 ### Tasmota Settings for iBeacon
 
@@ -70,7 +70,7 @@ If you have supported iBeacon Bluetooth devices in range, they will be discovere
 
 ![Showing data](_media/ibeacon_success.jpg)
 
-For a complete overview of supported devices, commands and features read the [Bluetooth article](Bluetooth#ibeacon)
+For a complete overview of supported devices, commands and features read the [Bluetooth article](ble/Bluetooth-Esp8266#ibeacon)
 
 ## Breakout Boards
 ![HM-10 Breakout](_media/peripherals/hm-10-1.jpg)![HM-10 Breakout](_media/peripherals/hm-10.jpg)

--- a/docs/NRF24L01.md
+++ b/docs/NRF24L01.md
@@ -50,4 +50,4 @@ The initial log should like this:
 The driver will do the rest automatically and start to look for known "special" packets, which will be used to extract the sensor readings.
 webUI and TELE-messages will be populated with sensor data.  This can take a while after start and may be influenced by the general traffic on the 2,4 GHz band.  
 
-For a complete overview of supported devices, commands and features read the [Bluetooth article](Bluetooth.md#ble-sensors-using-nrf24l01).
+For a complete overview of supported devices, commands and features read the [Bluetooth article](ble/Bluetooth-Esp8266#ble-sensors-using-nrf24l01).

--- a/docs/ble/Bluetooth-Esp32.md
+++ b/docs/ble/Bluetooth-Esp32.md
@@ -1,0 +1,345 @@
+Native Bluetooth Low Energy in Tasmota with ESP32:
+
+## ESP32 native Bluetooth Low Energy support
+This allows for the receiving of BLE advertisments from BLE devices, including "iBeacons" and BLE sensors, but also for the control of simple BLE devices, providing for reading, writing and receiving notifications. 
+
+Native ESP32 BLE depends on:
+
+`#define USE_BLE_ESP32` 
+
+There is a special Tasmota build '-bluetooth' which has this turned on.
+If you wish to combine it with other features (e.g. sensors), then add this to yout `user_config_override.h` and [compile your build](../Compile-your-build).
+
+Be aware, enabling of the native BLE on ESP32 has an impact on wifi performance.  Although later SDK helped a bit, expect more lag on the web interface and on MQTT.
+If only controlling BLE devices, then scanning can be disabled, which will minimise wifi impact.
+BLE can be enabled from the web UI menus. 
+
+This is compiled by default in the Bluetooth firmware, but you still need to enable it using the web interface `configure BLE` button or setoption115 1.
+
+## General Commands and Configuration
+
+Note that the only configuration stored is the setOption115 to turn BLE on and off.  All other configurations can be set at boot if necessary using Rules. (note that setoptiuon115 is the same as enable in the Web UI configuration).
+
+### Available BLE Commands
+
+Command|Parameters
+:---|:---
+BLEPeriod<a id="bleperiod"></a>|Set the period for publish of BLE data<BR>`<value>` = set interval in seconds
+BLEOp<a id="bleop"></a>|Setup and execute an active BLE operation (read/write/notify)<BR>see separate description in source code
+BLEMode<a id="blemode"></a>|Set the mode of the driver<BR>`<value>` 0 = Stop and Disable BLE. 1 = Enable BLE, but only scan on command. 2 = Enable BLE and scan regularly 
+BLEDetails<a id="bledetails"></a>|Display details about adverts for one or more devices.<BR>`BLEDetails0` - don't show any. `BLEDetails2 MAC|Alias` - show all advert details for the MAC or Alias. `BLEDetails3` - show ALL advert details.
+BLEScan<a id="blescan"></a>|Set the scan mode, or start a manual scan.<BR>`BLEScan0 <value>` 0 = passive scan, 1 = active scan. `BLEScan1 <ss>` start a manual scan for ss seconds (2-40), or 20s if ss not given.
+BLEAlias<a id="blealias"></a>|Set one or more aliases for device MAC addresses.<BR>`MAC=Alias <mac2=Alias2>`
+BLEName<a id="blename"></a>|Read or Write the BLE name for a device.<BR>`MAC|Alias` = read. `MAC|Alias name` = write.<BR>NOTE: This attempts to use BLE to actually write a name to a device - success is indicated in a BLEOperation.
+BLEDebug<a id="bledebug"></a>|Display more BLE related logs.<BR>`BLEDebug0` = less. `BLEDebug|BLEDebug1` = more.
+BLEDevices<a id="bledevices"></a>|Display or Clear seen BLE devices.<BR>`BLEDevices0` = clear device list. `BLEDevices1` = publish tele mesg.
+BLEMaxAge<a id="blemaxage"></a>|Display or Set the age at which a seen BLE device will be forgotten.<BR>`BLEMaxage` = display. `BLEMaxAge ss` = set to ss seconds.
+BLEAddrFilter<a id="bleaddrfilter"></a>|Display or Set the type od BLE addresses accepted.<BR>`BLEAddrFilter` = display. `BLEAddrFilter value` = set to value (0-default,1,2,3).  Set to 1 to hear certain devices with static random addresses. 
+
+
+### BLE Command examples
+
+
+#### Setup a rule to set some aliases at boot time
+```
+Rule1 ON System#Boot DO BLEAlias A4C1386A1E24=fred A4C1387FC1E1=james endon
+Rule1 1
+```
+
+#### Enable static random mac addresses in addition to public mac addresses
+```
+BLEAddrFilter 1
+```
+
+#### Check the interval between BLE tele messages
+```
+BLEPeriod
+```
+Set it to 40s
+```
+BLEPeriod 40
+```
+
+## iBeacon  
+
+Hear adverts from BLE devices, and produce MQTT messages containing RSSI and other information about them.  Break out iBeacon specific data if present. 
+
+
+Enabled by
+
+```
+#define USE_IBEACON          // Add support for bluetooth LE passive scan of ibeacon devices 
+```
+
+### Available iBeacon Commands
+
+Command|Parameters
+:---|:---
+iBeacon<a id="ibeacon"></a>|Show or set enable for the iBeacon driver<BR>`iBeacon` = Display 0|1<BR>`iBeacon 0` = disable<BR>`iBeacon 1` = enable.
+iBeaconOnlyAliased<a id="ibeacononlyaliased"></a>|Show or set OnlyAliased for the iBeacon driver<BR>`iBeaconOnlyAliased` = Display 0|1<BR>`iBeaconOnlyAliased 0` = enable iBeacon to hear ALL BLE devices<BR>`iBeaconOnlyAliased 1` = enable iBeacon to hear ONLY devices with valid BLEAlias<BR>`iBeaconOnlyAliased 2` = enable iBeacon to hear ONLY devices with valid BLEAlias starting `iB`
+iBeaconClear<a id="ibeaconclear"></a>|Clear iBeacon list
+iBeaconPeriod<a id="ibeaconperiod"></a>|Display or Set the period for publish of iBeacon data<BR>`iBeaconPeriod` = display interval<BR>`iBeaconPeriod ss` = set interval in seconds
+iBeaconTimeout<a id="ibeacontimeout"></a>|Display or Set the timeout for iBeacon devices<BR>`iBeaconTimeout` = display timeout<BR>`iBeaconTimeout ss` = set timeout in seconds
+
+
+This driver reports all beacons found during a scan with its ID (derived from beacon's MAC address) prefixed with `IBEACON_` and RSSI value.
+
+Every beacon report is published as an MQTT tele/%topic%/SENSOR in a separate message:
+
+```json
+tele/ibeacon/SENSOR = {"Time":"2021-01-02T12:08:40","IBEACON":{"MAC":"A4C1387FC1E1","RSSI":-56,"STATE":"ON"}}
+```
+
+If the beacon can no longer be found during a scan and the timeout interval has passed the beacon's RSSI is set to zero (0) and it is no longer displayed in the webUI
+
+```json
+tele/ibeacon/SENSOR = {"Time":"2021-01-02T12:08:40","IBEACON":{"MAC":"A4C1387FC1E1","RSSI":-56,"STATE":"OFF"}}
+```
+
+Additional fields will be present depending upon the beacon, e.g. NAME, UID, MAJOR, MINOR.
+
+### iBeacon MQTT fields
+
+#### Always present
+json|meaning
+:---|:---
+Time|time of MQTT send
+IBEACON.MAC|mac addr
+IBEACON.RSSI|signal strength
+IBEACON.STATE|ON - present, OFF - last MQTT you will get for now (device removed)
+
+#### Optional
+json|meaning
+:---|:---
+IBEACON.NAME|name if in scan, or BLEAlias if set - only present if NAME present
+IBEACON.PERSEC|count of adverts per sec.  Useful for detecting button press
+IBEACON.MAJOR|some iBeacon related term? - only present for some
+IBEACON.MINOR|some iBeacon related term? - only present for some
+
+### iBeacon Command examples
+
+#### Setup a rule to set some aliases at boot time, and only allow those starting `iB`
+```
+Rule1 ON System#Boot DO backlog iBeacon 1; BLEAlias A4C1386A1E24=iBfred A4C1387FC1E1=iBjames; iBeaconOnlyAliased 2 endon
+Rule1 1
+```
+
+### Supported Devices
+<img src="../../_media/bluetooth/nRF51822.png" width=155 align="right">
+
+All Apple compatible iBeacon devices should be discoverable. 
+
+Various nRF51822 beacons should be fully Apple compatible, programmable and their battery lasts about a year.
+
+- [Amazon.com](https://www.amazon.com/s?k=nRF51822+4.0)
+- [Aliexpress](https://www.aliexpress.com/af/NRF51822-beacon.html)
+
+Cheap "iTag" beacons with a beeper. The battery on these lasts only about a month.
+
+- [Aliexpress](https://www.aliexpress.com/af/itag.html?trafficChannel=af&SearchText=itag&ltype=affiliate&SortType=default&g=y&CatId=0)
+- [eBay](https://www.ebay.de/sch/i.html?_from=R40&_trksid=m570.l1313&_nkw=Smart-Tag-GPS-Tracker-Bluetooth-Anti-verlorene-Alarm-Key-Finder-Haustier-Kind&_sacat=0)
+- [Amazon.com](https://www.amazon.com/s?k=itag+tracker+4.0)
+
+<img src="../../_media/bluetooth/itag.png" width=225><img src="../../_media/bluetooth/itag2.png" width=225><img src="../../_media/bluetooth/itag3.png" width=225>
+
+!!! tip
+    You can activate a beacon with a beeper using command `IBEACON_%BEACONID%_RSSI 99` (ID is visible in webUI and SENSOR reports). This command can freeze the Bluetooth module and beacon scanning will stop. After a reboot of Tasmota the beacon will start beeping and scanning will resume. (untested on ESP32 native BLE)  
+  
+
+
+
+## `MI32` Bluetooth Low Energy Sensors
+
+Enabled by
+```
+#define USE_MI_ESP32
+```
+
+
+Different vendors offer Bluetooth solutions as part of the XIAOMI family often under the MIJIA-brand (while AQUARA is the typical name for a ZigBee sensor).  
+The sensors supported by Tasmota use BLE (Bluetooth Low Energy) to transmit the sensor data, but they differ in their accessibilities quite substantially.  
+  
+Basically all of them use of so-called „MiBeacons“ which are BLE advertisement packets with a certain data structure, which are broadcasted by the devices automatically while the device is not in an active bluetooth connection.  
+The frequency of these messages is set by the vendor and ranges from one per 3 seconds to one per hour (for the battery status of the LYWSD03MMC). Motion sensors and BLE remote controls start to send when an event is triggered.  
+These packets already contain the sensor data and can be passively received by other devices and will be published regardless if a user decides to read out the sensors via connections or not. Thus the battery life of a BLE sensor is not influenced by reading these advertisements and the big advantage is the power efficiency as no active bi-directional connection has to be established. The other advantage is, that scanning for BLE advertisements can happen nearly parallel (= very quick one after the other), while a direct connection must be established for at least a few seconds and will then block both involved devices for that time.  
+This is therefore the preferred option, if technically possible (= for the supported sensors).
+  
+Most of the „older“ BLE-sensor-devices use unencrypted messages, which can be read by all kinds of BLE-devices or even a NRF24L01. With the arrival of "newer" sensors came the problem of encrypted data in MiBeacons, which can be decrypted in Tasmota (not yet with the HM-1x).  
+Meanwhile it is possible to get the needed "bind_key" with the help of an open-source project: https://atc1441.github.io/TelinkFlasher.html  
+At least the LYWSD03 allows the use of a simple BLE connection without any encrypted authentication and the reading of the sensor data using normal subscription methods to GATT-services (currently used on the HM-1x). This is more power hungry than the passive reading of BLE advertisements.  
+Other sensors like the MJYD2S are not usable without the "bind_key".  
+  
+### Supported Devices
+
+!!! note "It can not be ruled out, that changes in the device firmware may break the functionality of this driver completely!"  
+
+The naming conventions in the product range of bluetooth sensors in XIAOMI-universe can be a bit confusing. The exact same sensor can be advertised under slightly different names depending on the seller (Mijia, Xiaomi, Cleargrass, ...).
+
+ <table>
+  <tr>
+    <th class="th-lboi">MJ_HT_V1</th>
+    <th class="th-lboi">LYWSD02</th>
+    <th class="th-lboi">CGG1</th>
+    <th class="th-lboi">CGD1</th>
+  </tr>
+  <tr>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/mj_ht_v1.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/LYWDS02.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/CGG1.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/CGD1.png" width=200></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+  </tr>
+    <tr>
+    <td class="tg-lboi">passive for all entities, reliable battery value</td>
+    <td class="tg-lboi">battery only active, thus not on the NRF24L01, set clock and unit, very frequent data sending</td>
+    <td class="tg-lboi">passive for all entities, reliable battery value</td>
+    <td class="tg-lboi">battery only active, thus not on the NRF24L01, no reliable battery value, no clock functions</td>
+  </tr>
+</table>  
+  
+ <table>
+  <tr>
+    <th class="th-lboi">MiFlora</th>
+    <th class="th-lboi">LYWSD03MMC / ATC</th>
+    <th class="th-lboi">NLIGHT</th>
+    <th class="th-lboi">MJYD2S</th>
+  </tr>
+  <tr>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/miflora.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/LYWSD03MMC.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/nlight.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/mjyd2s.png" width=200></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">temperature, illuminance, soil humidity, soil fertility, battery, firmware version</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">motion</td>
+    <td class="tg-lboi">motion, illuminance, battery, no-motion-time</td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">passive only with newer firmware (>3.0?), battery only active, thus not on the NRF24L01</td>
+    <td class="tg-lboi">passive only with decryption or using custom ATC-firmware, no reliable battery value with stock firmware</td>
+    <td class="tg-lboi">NRF24L01, ESP32</td>
+    <td class="tg-lboi">passive only with decryption, thus only NRF24L01, ESP32</td>
+  </tr>
+</table>  
+  
+ <table>
+  <tr>
+    <th class="th-lboi">YEE RC</th>
+    <th class="th-lboi">MHO-C401</th>
+    <th class="th-lboi">MHO-C303</th>
+  </tr>
+  <tr>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/yeerc.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/MHO-C401.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/MHO-C303.png" width=200></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">button press (single and long)</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+  </tr>
+     <tr>
+    <td class="tg-lboi">passive</td>
+    <td class="tg-lboi">equal to the LYWS03MMC, but no custom firmware yet</td>
+    <td class="tg-lboi">passive for all entities,  set clock and unit, no alarm functions, very frequent data sending</td>
+  </tr>
+</table> 
+passive: data is received via BLE advertisments  
+active: data is received via bidrectional connection to the sensor  
+  
+#### Devices with payload encryption  
+  
+The LYWSD03MMC, MHO-C401 and the MJYD2S will start to send advertisements with encrypted sensor data after pairing it with the official Xiaomi app (using TelinkFlasher to get the key also acts as a trigger to start sending?). Out-of-the-box the sensors do only publish a static advertisement.  
+It is possible to do a pairing and get the necessary decryption key ("bind_key") here: https://atc1441.github.io/TelinkFlasher.html - note you do not have to flash the ATC firmware! 
+This project also provides a custom firmware for the LYWSD03MMC, which then becomes an ATC and is supported by Tasmota too. Default ATC-setting will drain the battery more than stock firmware, because of very frequent data sending.  
+
+An encrypted sensor will show a link to the telelink flasher page, marked as 'NoKey' if an encrypted packet has been received and no key is present (you may wait some minutes before an encrypted packet arrives).
+
+To set the key(s) for a device(s) the key command is
+
+`MI32Keys mac|alias=key mac|alias=key`
+or
+`MI32Key keymac`
+
+where mac is a mac address.  A BLEAlias may be used in place of the mac (see BLE commands).  The Key is the 32 character (16 byte) key retrieved by TelelinkFlasher.  `MI32Key` is retained for b ackward compatibility, needing a 44 character combination of key and MAC.
+
+LYWSD03MMC sends encrypted sensor data every 10 minutes. As there are no confirmed reports about correct battery presentation of the sensor (always shows 99%), this function is currently not supported.  
+MJYD2S sends motion detection events and 2 discrete illuminance levels (1 lux or 100 lux for a dark or bright environment). Additionally battery level and contiguous time without motion in discrete growing steps (no motion time = NMT).    
+ 
+  
+##### Options to read out the LYWSD03MMC  
+  
+1. Generate a bind_key  
+The web-tool https://atc1441.github.io/TelinkFlasher.html allows the generation of a so-called bind_key by faking a pairing with the Xiaomi cloud. You can copy-paste this key and add the MAC to use this resultig key-MAC-string with key-command (NRFkey or MI32key). Then the driver will receive the sensors data roughly every 10 minutes (in two chunks for humidity and temperature with about a minute in between) and decode the data. This is the most energy efficient way. 
+The current way of storing these keys on the ESP32 is to use RULES like that (for the NRF24L01 you would use NRFkey):  
+```haskell
+rule1 on System#Boot do backlog MI32key 00112233445566778899AABBCCDDEEFF112233445566; MI32key 00112233445566778899AABBCCDDEEFFAABBCCDDEEFF endon
+```  
+This option is currently not available for the HM-10 because of memory considerations as part of the standard sensor-firmware package.  
+
+Note: in the latest Tasmota, a blue link will show next to a device if the device needs a key.  Clicking this likn will take you to a page guiding you to create a key, and at the end, puts that key into Tasmota, leaving you on a page with the required command to add to your rule. 
+
+2. Flash custom ATC-firmware  
+Use the same https://atc1441.github.io/TelinkFlasher.html to flash a custom ATC-firmware on the LYWSD03MMC. This will work out of the box with all three Tasmota-drivers. There is a slight chance of bricking the sensor, which would require some soldering and compiling skills to un-brick. This firmware does send data more frequently and is a little bit more power hungry than the stock firmware.  
+There is also another new custom firmware here https://github.com/pvvx/ATC_MiThermometer with it's own flasher/config page.
+The Custom mode is supported in latest Tasmota ESP32, but beware not to use 'All' mode.
+  
+3. Use active connections  
+By default a device without a key ,may be read using an active connection. This circumvents the data encryption, but is power hungry and drains the battery fast. Thus it is only recommended as fallback mechanism.
+
+
+#### Commands
+
+Command|Parameters
+:---|:---
+MI32Period<a id="mi32period"></a>|Show interval in seconds between sensor read cycles for the LYWSD03. Set to TelePeriod value at boot.<BR>|`<value>` = set interval in seconds
+MI32Time <a id="mi32time"></a>|`<n>` = set time time of a **LYWSD02 only** sensor to Tasmota UTC time and timezone. `<n>` is the sensor number in order of discovery starting with 0 (topmost sensor in the webUI list).
+MI32Unit <a id="mi32unit"></a>|`<n>` = toggle the displayed temperature units of a **LYWSD02 only** sensor. `<n>` is the sensor number in order of discovery starting with 0 (topmost sensor in the webUI list).  Reporting of the temperature is always in Celcius, this only changes the value shown on the device.
+MI32Page<a id="mi32page"></a>|Show the maximum number of sensors shown per page in the webUI list.<BR>`<value>` = set number of sensors _(default = 4)_
+MI32Battery<a id="mi32battery"></a>|Reads missing battery data for LYWSD02, Flora and CGD1.
+MI32Key<a id="mi32key"></a>| (depreciated - pls use MI32Keys) Set a "bind_key" for a MAC-address to decrypt sensor data (LYWSD03MMC, MJYD2S). The argument is a 44 uppercase characters long string, which is the concatenation of the bind_key and the corresponding MAC.<BR>`<00112233445566778899AABBCCDDEEFF>` (32 characters) = bind_key<BR>`<112233445566>` (12 characters) = MAC of the sensor<BR>`<00112233445566778899AABBCCDDEEFF112233445566>` (44 characters)= final string
+MI32Keys<a id="mi32keys"></a>| Set one or more "bind_key" for a MAC-address to decrypt sensor data (LYWSD03MMC, MJYD2S).<BR>`MI32Keys mac=key (mac=key)` = set the 32 character key for `<mac>` (more than one mac=key may be specified).
+MI32Blockx <a id="mi32block"></a>| Ignore Xiaomi sensors using the (fixed) MAC-address<BR>x=1 - show block list<BR>x=0 - delete block list<BR> x=1 + MAC-address - add MAC to to be blocked to the block list<BR>x=0 + MAC-address - remove MAC to to be blocked to the block list<BR>`<value>` (12 or 17 characters) = MAC interpreted as a string `AABBCCDDEEFF` (also valid: `aa:BB:cc:dd:EE:FF`)
+MI32Optionx n<a id="mi32option"></a>| Set driver options at runtime<BR> x=0 - 0 -> sends only recently received sensor data, 1 -> aggregates all recent sensors data types<BR>x=1 - 0 -> shows full sensor data at TELEPERIOD, 1 -> shows no sensor data at TELEPERIOD<BR>x=2 - 0 -> sensor data only at TELEPERIOD (default and "usual" Tasmota style), 1 -> direct bridging of BLE-data to mqtt-messages<BR>x=5 - 0 -> show all relevant BLE sensors, 1 -> show only sensors with a BLEAlias<BR>x=6 (from v 9.0.2.1) 1 -> always use MQTT Topic like `tele/tasmota_ble/<name>` containing only one sensor
+  
+!!! tip 
+If you really want to read battery for LYWSD02, Flora and CGD1, consider doing it once a day with a RULE:
+`RULE1 on Time#Minute=30 do MI32Battery endon`
+This will update every day at 00:30 AM.  
+  
+
+### MI32 MQTT messages
+
+Because we can have MANY sensors reporting, tele messages are chunked to have a maximum of four sensors per message.
+
+If you enable HASS discovery (setoption19 1), the ADDITIONAL MQTT messages are send.
+(note: from 9.0.2.1, you can enable the below style of MQTT using 'MI32Option6 1' - even if not using HASS discovery mode.)
+
+Primarily, at teleperiod or MI32period, discovery messages are sent.  These inform homeassistant of the devices.  Device names can be dependent upon BLEAlias, so set BLEAlias at boot....
+
+Additional actual data messages are sent on topics includinmg the device name:
+
+```
+tele/tasmota_ble/<name>
+```
+
+Each message for ONE sensor.
+
+These messages can be used without homeassistant if it is a preferred format.
+
+NOTE: The topic would be the SAME from all Tasmota if they have the same BLEAlias or no BLEAlias.  So if you wish to 'hear' the same device separately from different Tasmota, use different BLEAlias names.... 
+
+
+## EQ3 radiator valve driver
+
+A preliminary EQ3 driver is in production
+
+[Documentation](EQ3-TRV_with_BLE-ESP32.md) 
+

--- a/docs/ble/Bluetooth-Esp8266.md
+++ b/docs/ble/Bluetooth-Esp8266.md
@@ -1,0 +1,296 @@
+Bluetooth Low Energy in Tasmota on Esp8266 consists of:
+
+## ESP8266 via HM-1x or nRF24L01(+)
+This allows for the receiving of BLE advertisments from BLE devices, including "iBeacons"
+
+## iBeacon  
+
+!!! info "This feature is included only in tasmota-sensors.bin"
+Otherwise you must [compile your build](../Compile-your-build). Add the following to `user_config_override.h`:
+
+### For ESP8266 via HM-1x or nRF24L01(+)
+  
+Tasmota uses a BLE 4.x module to scan for [iBeacon](https://en.wikipedia.org/wiki/IBeacon) devices. This driver is working with [HM-10 and clones](../HM-10) and [HM16/HM17](../HM-17) Bluetooth modules and potentially with other HM-1x modules depending on firmware capabilities.
+
+!!! tip
+    If using an extenral module, When first connected some modules will be in peripheral mode. You have to change it to central mode using commands `Sensor52 1` and `Sensor52 2`.
+
+### Features
+For a list of all available commands see [Sensor52](../Commands.md#sensor52) command.  
+
+This driver reports all beacons found during a scan with its ID (derived from beacon's MAC address) prefixed with `IBEACON_` and RSSI value.
+
+Every beacon report is published as an MQTT tele/%topic%/SENSOR in a separate message:
+
+```json
+tele/ibeacon/SENSOR = {"Time":"2021-01-02T12:08:40","IBEACON":{"MAC":"A4C1387FC1E1","RSSI":-56,"STATE":"ON"}}
+```
+
+If the beacon can no longer be found during a scan and the timeout interval has passed the beacon's RSSI is set to zero (0) and it is no longer displayed in the webUI
+
+```json
+tele/ibeacon/SENSOR = {"Time":"2021-01-02T12:08:40","IBEACON":{"MAC":"A4C1387FC1E1","RSSI":-56,"STATE":"OFF"}}
+```
+
+Additional fields will be present depending upon the beacon, e.g. NAME, UID, MAJOR, MINOR.
+
+
+### Supported Devices
+<img src="../../_media/bluetooth/nRF51822.png" width=155 align="right">
+
+All Apple compatible iBeacon devices should be discoverable. 
+
+Various nRF51822 beacons should be fully Apple compatible, programmable and their battery lasts about a year.
+
+- [Amazon.com](https://www.amazon.com/s?k=nRF51822+4.0)
+- [Aliexpress](https://www.aliexpress.com/af/NRF51822-beacon.html)
+
+
+Cheap "iTag" beacons with a beeper. The battery on these lasts only about a month.
+
+- [Aliexpress](https://www.aliexpress.com/af/itag.html?trafficChannel=af&SearchText=itag&ltype=affiliate&SortType=default&g=y&CatId=0)
+- [eBay](https://www.ebay.de/sch/i.html?_from=R40&_trksid=m570.l1313&_nkw=Smart-Tag-GPS-Tracker-Bluetooth-Anti-verlorene-Alarm-Key-Finder-Haustier-Kind&_sacat=0)
+- [Amazon.com](https://www.amazon.com/s?k=itag+tracker+4.0)
+
+<img src="../../_media/bluetooth/itag.png" width=225><img src="../../_media/bluetooth/itag2.png" width=225><img src="../../_media/bluetooth/itag3.png" width=225>
+
+!!! tip
+    You can activate a beacon with a beeper using command `IBEACON_%BEACONID%_RSSI 99` (ID is visible in webUI and SENSOR reports). This command can freeze the Bluetooth module and beacon scanning will stop. After a reboot of Tasmota the beacon will start beeping and scanning will resume. (untested on ESP32 native BLE)
+  
+  
+  
+## Bluetooth Low Energy Sensors
+
+Different vendors offer Bluetooth solutions as part of the XIAOMI family often under the MIJIA-brand (while AQUARA is the typical name for a ZigBee sensor).  
+The sensors supported by Tasmota use BLE (Bluetooth Low Energy) to transmit the sensor data, but they differ in their accessibilities quite substantially.  
+  
+Basically all of them use of so-called „MiBeacons“ which are BLE advertisement packets with a certain data structure, which are broadcasted by the devices automatically while the device is not in an active bluetooth connection.  
+The frequency of these messages is set by the vendor and ranges from one per 3 seconds to one per hour (for the battery status of the LYWSD03MMC). Motion sensors and BLE remote controls start to send when an event is triggered.  
+These packets already contain the sensor data and can be passively received by other devices and will be published regardless if a user decides to read out the sensors via connections or not. Thus the battery life of a BLE sensor is not influenced by reading these advertisements and the big advantage is the power efficiency as no active bi-directional connection has to be established. The other advantage is, that scanning for BLE advertisements can happen nearly parallel (= very quick one after the other), while a direct connection must be established for at least a few seconds and will then block both involved devices for that time.  
+This is therefore the preferred option, if technically possible (= for the supported sensors).
+  
+Most of the „older“ BLE-sensor-devices use unencrypted messages, which can be read by all kinds of BLE-devices or even a NRF24L01. With the arrival of "newer" sensors came the problem of encrypted data in MiBeacons, which can be decrypted in Tasmota (not yet with the HM-1x).  
+Meanwhile it is possible to get the needed "bind_key" with the help of an open-source project: https://atc1441.github.io/TelinkFlasher.html  
+At least the LYWSD03 allows the use of a simple BLE connection without any encrypted authentication and the reading of the sensor data using normal subscription methods to GATT-services (currently used on the HM-1x). This is more power hungry than the passive reading of BLE advertisements.  
+Other sensors like the MJYD2S are not usable without the "bind_key".  
+  
+### Supported Devices
+
+!!! note "It can not be ruled out, that changes in the device firmware may break the functionality of this driver completely!"  
+
+The naming conventions in the product range of bluetooth sensors in XIAOMI-universe can be a bit confusing. The exact same sensor can be advertised under slightly different names depending on the seller (Mijia, Xiaomi, Cleargrass, ...).
+
+ <table>
+  <tr>
+    <th class="th-lboi">MJ_HT_V1</th>
+    <th class="th-lboi">LYWSD02</th>
+    <th class="th-lboi">CGG1</th>
+    <th class="th-lboi">CGD1</th>
+  </tr>
+  <tr>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/mj_ht_v1.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/LYWDS02.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/CGG1.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/CGD1.png" width=200></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+  </tr>
+    <tr>
+    <td class="tg-lboi">passive for all entities, reliable battery value</td>
+    <td class="tg-lboi">battery only active, thus not on the NRF24L01, set clock and unit, very frequent data sending</td>
+    <td class="tg-lboi">passive for all entities, reliable battery value</td>
+    <td class="tg-lboi">battery only active, thus not on the NRF24L01, no reliable battery value, no clock functions</td>
+  </tr>
+</table>  
+  
+ <table>
+  <tr>
+    <th class="th-lboi">MiFlora</th>
+    <th class="th-lboi">LYWSD03MMC / ATC</th>
+    <th class="th-lboi">NLIGHT</th>
+    <th class="th-lboi">MJYD2S</th>
+  </tr>
+  <tr>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/miflora.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/LYWSD03MMC.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/nlight.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/mjyd2s.png" width=200></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">temperature, illuminance, soil humidity, soil fertility, battery, firmware version</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">motion</td>
+    <td class="tg-lboi">motion, illuminance, battery, no-motion-time</td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">passive only with newer firmware (>3.0?), battery only active, thus not on the NRF24L01</td>
+    <td class="tg-lboi">passive only with decryption or using custom ATC-firmware, no reliable battery value with stock firmware</td>
+    <td class="tg-lboi">NRF24L01, ESP32</td>
+    <td class="tg-lboi">passive only with decryption, thus only NRF24L01, ESP32</td>
+  </tr>
+</table>  
+  
+ <table>
+  <tr>
+    <th class="th-lboi">YEE RC</th>
+    <th class="th-lboi">MHO-C401</th>
+    <th class="th-lboi">MHO-C303</th>
+  </tr>
+  <tr>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/yeerc.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/MHO-C401.png" width=200></td>
+    <td class="tg-lboi"><img src="../../_media/bluetooth/MHO-C303.png" width=200></td>
+  </tr>
+  <tr>
+    <td class="tg-lboi">button press (single and long)</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+    <td class="tg-lboi">temperature, humidity, battery</td>
+  </tr>
+     <tr>
+    <td class="tg-lboi">passive</td>
+    <td class="tg-lboi">equal to the LYWS03MMC, but no custom firmware yet</td>
+    <td class="tg-lboi">passive for all entities,  set clock and unit, no alarm functions, very frequent data sending</td>
+  </tr>
+</table> 
+passive: data is received via BLE advertisments  
+active: data is received via bidrectional connection to the sensor  
+  
+#### Devices with payload encryption  
+  
+The LYWSD03MMC, MHO-C401 and the MJYD2S will start to send advertisements with encrypted sensor data after pairing it with the official Xiaomi app (using TelinkFlasher to get the key also acts as a trigger to start sending?). Out-of-the-box the sensors do only publish a static advertisement.  
+It is possible to do a pairing and get the necessary decryption key ("bind_key") here: https://atc1441.github.io/TelinkFlasher.html - note you do not have to flash the ATC firmware! 
+This project also provides a custom firmware for the LYWSD03MMC, which then becomes an ATC and is supported by Tasmota too. Default ATC-setting will drain the battery more than stock firmware, because of very frequent data sending.  
+
+For NRF based BLE:
+This key and the corresponding MAC of the sensor can be injected with the NRFKEY-command (or NRFMJYD2S). It is probably a good idea to save the whole config as RULE like that:  
+  
+```haskell
+rule1 on System#Boot do backlog NRFkey 00112233445566778899AABBCCDDEEFF112233445566; NRFkey 00112233445566778899AABBCCDDEEFF112233445566; NRFPage 6; NRFUse 0; NRFUse 4 endon
+```  
+(key for two sensors, 6 sensors per page in the WebUI, turn off all sensors, turn on LYWS03)  
+
+
+LYWSD03MMC sends encrypted sensor data every 10 minutes. As there are no confirmed reports about correct battery presentation of the sensor (always shows 99%), this function is currently not supported.  
+MJYD2S sends motion detection events and 2 discrete illuminance levels (1 lux or 100 lux for a dark or bright environment). Additionally battery level and contiguous time without motion in discrete growing steps (no motion time = NMT).    
+ 
+  
+#### Working principle of Tasmota BLE drivers (>8.5.)
+  
+The idea is to provide drivers with as many automatic functions as possible. Besides the hardware setup, there are zero or very few things to configure.  
+The sensor namings are based on the original sensor names and shortened if appropriate (Flower care -> Flora). A part of the MAC will be added to the name as a suffix.  
+All sensors are treated as if they are physically connected to the ESP8266 device. For motion and remote control sensors MQTT-messages will be published in (nearly) real time.
+The ESP32 and the HM-1x-modules are real BLE devices whereas the NRF24L01 (+) is only a generic 2.4 GHz transceiver with very limited capabilities.  
+
+
+##### Options to read out the LYWSD03MMC  
+  
+1. Generate a bind_key  
+The web-tool https://atc1441.github.io/TelinkFlasher.html allows the generation of a so-called bind_key by faking a pairing with the Xiaomi cloud. You can copy-paste this key and add the MAC to use this resultig key-MAC-string with key-command (NRFkey or MI32key). Then the driver will receive the sensors data roughly every 10 minutes (in two chunks for humidity and temperature with about a minute in between) and decode the data. This is the most energy efficient way. 
+The current way of storing these keys on the ESP32 is to use RULES like that (for the NRF24L01 you would use NRFkey):  
+```haskell
+rule1 on System#Boot do backlog MI32key 00112233445566778899AABBCCDDEEFF112233445566; MI32key 00112233445566778899AABBCCDDEEFFAABBCCDDEEFF endon
+```  
+This option is currently not available for the HM-10 because of memory considerations as part of the standard sensor-firmware package.  
+
+2. Flash custom ATC-firmware  
+Use the same https://atc1441.github.io/TelinkFlasher.html to flash a custom ATC-firmware on the LYWSD03MMC. This will work out of the box with all three Tasmota-drivers. There is a slight chance of bricking the sensor, which would require some soldering and compiling skills to un-brick. This firmware does send data more frequently and is a little bit more power hungry than the stock firmware.  
+There is also another new custom firmware here https://github.com/pvvx/ATC_MiThermometer with it's own flasher/config page.
+The Custom mode is supported in latest Tasmota ESP32, but beware not to use 'All' mode.
+  
+3. Use active connections  
+By default on the HM-10 (for legacy reasons) the method to connect to the sensor from time to time. This circumvents the data encryption. This is very power hungry and drains the battery fast. Thus it is only recommended as fallback mechanism.
+
+  
+## BLE Sensors using HM-1x
+
+!!! info "This feature is included only in tasmota-sensors.bin"
+Otherwise you must [compile your build](../Compile-your-build). Add the following to `user_config_override.h`:
+
+```
+#ifndef USE_HM10
+#define USE_HM10          // Add support for HM-10 as a BLE-bridge (+9k3 code)
+#endif
+```
+
+### Features
+Supported sensors will be connected to at a set interval (default interval equals TelePeriod). A subscription is established for 5 seconds and data (e.g. temperature, humidity and battery) is read and reported to an mqtt topic (Dew point is calculated):
+
+```json
+tele/%topic%/SENSOR = {"Time":"2020-03-24T12:47:51","LYWSD03-52680f":{"Temperature":21.1,"Humidity":58.0,"DewPoint":12.5,"Battery":100},"LYWSD02-a2fd09":{"Temperature":21.4,"Humidity":57.0,"DewPoint":12.5,"Battery":2},"MJ_HT_V1-d8799d":{"Temperature":21.4,"Humidity":54.6,"DewPoint":11.9},"TempUnit":"C"}
+```
+
+After a completed discovery scan, the driver will report the number of found sensors. As Tasmota can not know how many sensors are meant to be discovered you have to force a re-scan until the desired number of devices is found.
+```haskell
+Rule1 ON HM10#Found<6 DO Add1 1 ENDON ON Var1#State<=3 DO HM10Scan ENDON 
+```
+This will re-scan up to 3 times if less than 6 sensors are found.
+
+#### Commands
+
+Command|Parameters
+:---|:---
+HM10Scan<a id="hm10scan"></a>|Start a new device discovery scan
+HM10Period<a id="hm10period"></a>|Show interval in seconds between sensor read cycles. Set to TelePeriod value at boot.<BR>|`<value>` = set interval in seconds
+HM10Baud<a id="hm10baud"></a>|Show ESP8266 serial interface baudrate (***Not HM-10 baudrate***)<BR>`<value>` = set baudrate
+HM10AT<a id="hm10at"></a>|`<command>` = send AT commands to HM-10. See [list](http://www.martyncurrey.com/hm-10-bluetooth-4ble-modules/#HM-10%20-%20AT%20commands)
+HM10Time <a id="hm10time"></a>|`<n>` = set time time of a **LYWSD02 only** sensor to Tasmota UTC time and timezone. `<n>` is the sensor number in order of discovery starting with 0 (topmost sensor in the webUI list).
+HM10Auto <a id="hm10auto"></a>|`<value>` = start an automatic discovery scan with an interval of  `<value>` seconds to receive data in BLE advertisements periodically.<BR>This is a passive scan and does not produce a scan response from the BLE sensor. It does not increase the sensors battery drain.
+HM10Page<a id="hm10page"></a>|Show the maximum number of sensors shown per page in the webUI list.<BR>`<value>` = set number of sensors _(default = 4)_
+HM10Beaconx <a id="HM10beacon"></a>| Set a BLE device as a beacon using the (fixed) MAC-address<BR>x - set beacon 1 .. 4 <BR> x= 0 - will start a BLE scan and print result to the console <BR>`<value>` (12 or 17 characters) = use beacon given the MAC interpreted as a string `AABBCCDDEEFF` (also valid: `aa:BB:cc:dd:EE:FF`)  MAC of `00:00:00:00:00:00` will stop beacon x
+  
+  
+## BLE Sensors using nRF24L01(+)
+
+### Configuration
+  
+You must [compile your build](../Compile-your-build). Change the following in `my_user_config.h`:
+
+```
+// -- SPI sensors ---------------------------------
+#define USE_SPI                                  // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
+#ifdef USE_SPI
+  #define USE_NRF24                              // Add SPI support for NRF24L01(+) (+2k6 code)
+  #ifdef USE_NRF24
+    #define USE_MIBLE                            // BLE-bridge for some Mijia-BLE-sensors (+4k7 code)
+```    
+    
+Sensors will be discriminated by using the Product-ID of the MiBeacon. A human readable short product name will be shown instead of the company-assigned ID of the BLE Public Device Address (= the "lower" 24 bits). 
+
+A TELE message could like look this:  
+  
+```
+10:13:38 RSL: stat/tasmota/STATUS8 = {"StatusSNS":{"Time":"2019-12-18T10:13:38","Flora-6ab577":{"Temperature":21.7,"Illuminance":21,"Humidity":0,"Fertility":0},"MJ_HT_V1-3108be":{"Temperature":22.3,"Humidity":56.1},"TempUnit":"C"}}
+```
+  
+As the NRF24L01 can only read BLE-advertisements, only the data in these advertisements is accessible.  
+All sensors have an additional GATT-interface with more data in it, but it can not be read with a NRF24l01. 
+  
+As we can not use a checksum to test data integrity of the packet, only data of sensors whose adresses showed up more than once (default = 3 times) will be published. 
+Internally from time to time "fake" sensors will be created, when there was data corruption in the address bytes.  These will be removed automatically.  
+  
+  
+#### Commands
+
+Command|Parameters
+:---|:---
+NRFPage<a id="nrfpage"></a>|Show the maximum number of sensors shown per page in the webUI list.<BR>`<value>` = set number of sensors _(default = 4)_
+NRFIgnore<a id="nrfignore"></a>|`0` = all known sensor types active_(default)_<BR>`<value>` =  ignore certain sensor type (`1` = Flora, `2` = MJ_HT_V1, `3` = LYWSD02, `4` = LYWSD03, `5` = CGG1, `6` = CGD1, `7` = NLIGHT,`8` = MJYD2S,`9` = YEERC (DEPRECATED, please switch to NRFUSE)
+NRFUse<a id="nrfuse"></a>|`0` = all known sensor types inactive<BR>`<value>` =  ignore certain sensor type (`1` = Flora, `2` = MJ_HT_V1, `3` = LYWSD02, `4` = LYWSD03, `5` = CGG1, `6` = CGD1, `7` = NLIGHT,`8` = MJYD2S,`9` = YEERC
+NRFScan<a id="nrfscan"></a>| Scan for regular BLE-advertisements and show a list in the console<BR>`0` = start a new scan list<BR>`1` = append to the scan list<BR>`2` = stop running scan
+NRFBeacon<a id="nrfbeacon"></a>| Set a BLE device as a beacon using the (fixed) MAC-address<BR>`<value>` (1-3 digits) = use beacon from scan list<BR>`<value>` (12 characters) = use beacon given the MAC interpreted as an uppercase string `AABBCCDDEEFF`
+NRFKey<a id="nrfkey"></a>| Set a "bind_key" for a MAC-address to decrypt (LYWSD03MMC & MHO-C401). The argument is a 44 uppercase characters long string, which is the concatenation of the bind_key and the corresponding MAC.<BR>`<00112233445566778899AABBCCDDEEFF>` (32 characters) = bind_key<BR>`<112233445566>` (12 characters) = MAC of the sensor<BR>`<00112233445566778899AABBCCDDEEFF112233445566>` (44 characters)= final string
+NRFMjyd2s<a id="nrfmjyd2s"></a>| Set a "bind_key" for a MAC-address to decrypt sensor data of the MJYD2S. The argument is a 44 characters long string, which is the concatenation of the bind_key and the corresponding MAC.<BR>`<00112233445566778899AABBCCDDEEFF>` (32 characters) = bind_key<BR>`<112233445566>` (12 characters) = MAC of the sensor<BR>`<00112233445566778899AABBCCDDEEFF112233445566>` (44 characters)= final string
+NRFNlight<a id="nrfnlight"></a>| Set the MAC of an NLIGHT<BR>`<value>` (12 characters) =  MAC interpreted as an uppercase string `AABBCCDDEEFF`
+  
+  
+### Beacon  
+  
+A simplified presence dection will scan for regular BLE advertisements of a given BT-device defined by its MAC-address. It is important to know, that many new devices (nearly every Apple-device) will change its MAC every few minutes to prevent tracking.  
+If the driver receives a packet from the "beacon" a counter will be (re-)started with an increment every second. This timer is published in the TELE-message, presented in the webUI and processed as a RULE.
+The stability of regular readings will be strongly influenced by the local environment (many BLE-devices nearby or general noise in the 2.4-GHz-band). 
+
+  

--- a/docs/ble/EQ3-TRV_with_BLE-ESP32.md
+++ b/docs/ble/EQ3-TRV_with_BLE-ESP32.md
@@ -1,0 +1,199 @@
+This driver alows the control of Eqiva TRV's (i.e. Thermostat Radiator Valve). Compatible models are:
+
+[not in Tasmota source yet see here](https://github.com/btsimonh/Tasmota/tree/EQ3_2020-02-04)
+
+* Eqiva eQ-3 Bluetooth Smart (141771E0/141771E0A)
+* Eqiva eQ-3 Bluetooth Smart(UK Version) (142461D0)
+
+Other Eqiva EQ3 models should work as well, but make sure you select a bluetooth model as there are also non-bluetooth models.
+
+### Setup
+Before you can use the TRV you will need to enable bluetooth on the TRV:
+
+1. Press the Mode/Menu button for at least 3 seconds.
+1. Select the menu item `bLE` with the control wheel and confirm by pressing the
+control wheel shortly.
+1. The display will show `OFF` to deactivate the function or `On` to activate the
+function.
+1. Confirm by pressing the control wheel shortly.
+ 
+!!! Note "Note: No need to pair the TRV"
+
+Next you will need to make sure that BLE is enabled in Tasmota:
+
+1. Configuration
+1. Configure BLE
+1. Enable Bluetooth
+
+To determine the mac adresses of a trv:
+
+1. Go to the BLE menu in Tasmota
+1. Enable active scan
+1. In to the tasmota console: trv devlist
+
+This will give you the mac adress of each valve.
+
+!!! note
+
+    * Enable 1 valve at a time as this makes it easier to identify
+    * You might need to wait a minute or so or repeat the "trv devlist" command a few times before the devices have been properly identified
+    * Keep in mind that the TRV does NOT report the current temperature, only the requested, target, temperature. The Xiaomi Thermometer LYWSD03MMC makes a perfect combo for measuring the room temperature (~USD 4)
+
+### Operating your trv
+
+There are 2 ways to control your TRV:
+
+* The Tasmota Console (convenient for setup)<br>
+    syntax: `trv <MAC Address> <command> [options]`<br>
+    example: `trv 001A2216A458 settemp 21.5`
+* MQTT:<br>
+    syntax: `cmnd/<tasmota_topic>/EQ3/<MAC Address>/command [options]`<BR>
+    example: `cmnd/ble_esp32/EQ3/001A2216A458/settemp 22.5`
+
+As you can see from the example the MQTT topic is made of:
+
+* Standard Tasmota `%prefix%` : `cmnd`, `stat`
+* `%topic%` of the BLE_ESP32 gateway device, here `ble_esp32`
+* An `EQ3` element to specifiy this command is specifc to the EQ3 driver
+* The MAC address of the EQ3
+* The command to the EQ3 or result from the EQ3
+
+After submitting a command you will see one or more of the possible results.<BR>
+
+Status|Description
+:---|:---
+queued|Command has been accepted by the BLE driver
+DONENOTIFIED|Command has been successfully processed by the trv and the results are send in a json format
+ignoredbusy|Currently we can only accept a single command in the queue, during the processing of a trv command subsequent commands will be rejected. Please resubmit.
+FAILCONNECT|After 3 automatic retries we were not able to contact the trv and we give up. Please resubmit
+
+Under normal circumstance you will get a response from the valve (blestate DONENOTIFIED).
+``` json
+{
+    "trv":"00:1a:22:16:a4:58",
+    "blestate":"DONENOTIFIED",
+    "raw":"02010900041C000000001803201707",
+    "temp":14.0,
+    "posn":0,
+    "mode":"manual",
+    "boost":"inactive",
+    "dst":"set",
+    "window":"closed",
+    "state":"unlocked",
+    "battery":"GOOD",
+    "holidayend":"00-00-00 00:00"
+}
+```
+
+Field|Description
+:---|:---
+trv|mac address (should be the same as in the topic)
+blestate|ble driver status queued/DONENOTIFIED/ignoredbusy/FAILCONNECT
+raw|raw data as received from the device
+temp|target temperature
+posn|valve position (0=closed / 100=fully opened)
+mode|manual / auto (auto follows the week program, manual keeps the current requested temperature)
+boost|boost mode (valve opened 80 % for 5 minutes) active/inactive
+dst|Daylight savings time active active
+window|status of the window open functionality (activated when the temperature suddenly drops)
+state|child lock enabled (disables the buttons on the TRV)
+battery|battery status of the TRV
+holidayend|end of holiday mode
+
+### Available commands
+
+#### Base commands
+Command|Parameters
+:---|:---
+trvperiod<a class="cmnd" id="trvperiod"></a>|Display/Set the EQ3 poll interval in seconds
+trvonlyaliased<a class="cmnd" id="trvonlyaliased"></a>|Display/Set the EQ3 OnlyAliased parameter<BR>set to 1 for any aliased BLE devices<BR>set to 2 for only aliases starting with `EQ3`
+TrvMatchPrefix<a class="cmnd" id="trvmatchprefix"></a>|Display/Set the EQ3 MatchPrefix parameter<BR>set to 1 to not require active scan to identify EQ3 - identify from MAC (default)<BR>Set to 0 to disbale this matching
+
+#### TRV subcommands
+
+Command|Parameters
+:---|:---
+devlist<a class="cmnd" id="devlist"></a>|Display all trv's which have been found in BLE scan mode.<BR>No parameters.
+scan<a class="cmnd" id="blescan"></a>|Alias of devlist.<BR>No parameters.
+state<a class="cmnd" id="state"></a>|Current valve state without changing anything.<BR>No parameters.
+settemp<a class="cmnd" id="settemp"></a>|Set the desired target temperature.<BR>**Temperature**.
+valve<a class="cmnd" id="valve"></a>|Control the valve state.<BR>**off** Disable the trv and enable frost protection<BR>**on** Disable the trv and open the valve completely (saves potentially battery in summer while the central heating is not working).
+mode<a class="cmnd" id="mode"></a>|Define the current operating mode.<BR>**auto** run the week program as stored in the TRV.<BR>**day** Comfort temperature.<BR>**night** Reduction temperature.<BR>**Manual** disable the weekprogram and keep the temperature as selected (settemp/day/night).<BR>Note: When setting a temperature, switch to day or night mode, the TRV will switch back to the program at the next programmed timeslot.
+setdaynight<a class="cmnd" id="setdaynight"></a>|Change the comfort and reduction temperature.<BR>**daytemp nighttemp**.
+boost<a class="cmnd" id="boost"></a>|Activate boost mode (valve 80% open for 5 minutes).<BR>**1**<br>Note: once activated, boost mode cannot be stopped until end of the 5 minutes.
+lock<a class="cmnd" id="lock"></a>|Enable or disable TRV buttons.<BR>**0** Unlocks buttons<br>**1** Locks buttons.
+settime<a class="cmnd" id="settime"></a>|Synchronize current tasmota time to the TRV:<BR>No parameters.<BR>Send an alternate time to the TRV:<BR>**yyMMddhhmmss**<BR>(byte by byte conversion from decimal to hexadecimal).
+
+#### Examples
+Request the current status without changing anything:
+```
+cmnd/tasmota/EQ3/001A2216A458/state
+```
+
+set a target temperature (21.5 c)
+```
+cmnd/tasmota/EQ3/001A2216A458/settemp 21.5
+```
+
+Select TRV mode auto: run the week program as stored in the TRV
+```
+cmnd/tasmota/EQ3/001A2216A458/mode auto
+```
+
+Select TRV mode Day: Switch to comfort temperature
+```
+cmnd/tasmota/EQ3/001A2216A458/mode day
+```
+
+Select TRV mode Night: Switch to reduction temperature
+```
+cmnd/tasmota/EQ3/001A2216A458/mode night
+```
+
+Select TRV mode Manual: disable the weekprogram and keep the temperature as selected (settemp/day/night)
+```
+cmnd/tasmota/EQ3/001A2216A458/mode manual
+```
+
+!!! Note
+    When setting a temperature, switch to day or night mode, the TRV will switch back to the progarm at the next programmed timeslot.
+
+Disable the trv and enable frost protection:
+```
+cmnd/tasmota/EQ3/001A2216A458/valve off
+```
+
+Disable the trv and open the valve completely (saves potentially battery in summer while the central heating is not working):
+```
+cmnd/tasmota/EQ3/001A2216A458/valve on
+```
+
+Change the comfort and reduction temperature to 22C and 17.5C
+```
+cmnd/tasmota/EQ3/001A2216A458/setdaynight 22 17.5
+```
+
+Enable boost mode (valve 80% open for 5 minutes)
+```
+cmnd/tasmota/EQ3/001A2216A458/boost 1
+```
+
+Disable TRV buttons  
+```
+cmnd/tasmota/EQ3/001A2216A458/lock 1
+```
+
+Synchronize current tasmota time with the TRV
+```
+cmnd/tasmota/EQ3/001A2216A458/settime
+```
+
+Set the time and date (byte by byte conversion from decimal to hexadecimal)
+
+* Date:   2021 - jan - 04 - 13:00:00
+* In hex:   15 - 01  - 04 - 0d:00:00  (yyMMddhhmmss)
+* Concatenate: 1501040d0000 
+
+```
+cmnd/tasmota/EQ3/001A2216A458/settime 1501040d0000
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,8 @@ nav:
   - Features:
     - Introduction: Features.md
     - Analog pin: ADC.md
-    - Bluetooth.md
+    - Bluetooth ESP32: ble/Bluetooth-Esp32.md
+    - Bluetooth ESP8266: ble/Bluetooth-Esp8266.md
     - Buttons-and-Switches.md
     - DeepSleep.md
     - Device-Groups.md


### PR DESCRIPTION
Long awaited, should help with some of the questions.
There is probably more that could be added, but this is the basics for the moment.
Also splits the ESP32 stuff away from the use of external modules; keeps the docs cleaner.
I have added an EQ3 doc - this is for those building from my branch; it's still not stable, so not ready for a PR; but it's quietly linked off the bottom. (we had at least one other dev who started an EQ3 driver.... so want something in there to indicate how and where they can contribute...).

does not remove Bluetooth.md, but it is now not referenced.