### PR TITLE
Sonoff-Pow.md: update broken URL href link

### DIFF
--- a/docs/devices/Sonoff-Pow.md
+++ b/docs/devices/Sonoff-Pow.md
@@ -1,4 +1,4 @@
-Sonoff Pow has been obsoleted with [Sonoff Pow R2](https://blakadder.github.io/sonoff_dual_R2.html). Before configuring your device check which revision you have.
+Sonoff Pow has been obsoleted with [Sonoff Pow R2](https://tasmota.github.io/docs/devices/Sonoff-Pow-R2/). Before configuring your device check which revision you have.
 
 ## ⚠️️Special Attention   ⚠️️
 


### PR DESCRIPTION
https://blakadder.github.io/sonoff_dual_R2.html link moved to https://templates.blakadder.com/sonoff_Pow_R2.html but I still think it's better to reference the docs link instead of an external one