### PR TITLE
Zigbee documentation update

### DIFF
--- a/docs/Zigbee.md
+++ b/docs/Zigbee.md
@@ -1,4 +1,5 @@
-!!! info "Zigbee2Tasmota serves as a gateway for devices connected to a Zigbee wireless network to bridge their communications over to Wi-Fi"
+<!-- Required extensions: pymdownx.betterem, pymdownx.tilde, pymdownx.emoji, pymdownx.tasklist, pymdownx.superfences -->
+**Zigbee2Tasmota serves as a gateway for devices connected to a Zigbee wireless network to bridge their communications over to Wi-Fi**
 
 Zigbee2Tasmota (Z2T) is a lightweight Zigbee solution running on an ESP82xx Wi-Fi chip. Hence it is easier to deploy wherever you want in your home. It is largely inspired by [Zigbee2mqtt](https://www.zigbee2mqtt.io/) but it's a complete rewrite to make it fit on an ESP82xx with 80kB of RAM and only 1MB of flash memory.
 
@@ -452,8 +453,7 @@ Command `ZbLight` configures a Zigbee device to be Alexa controllable. Specify t
 * `4` RGBW Light
 * `5` RGBCW Light, RGB and  Cold/Warm White
 
-To set the light, use `ZbLight <device>,<nb_of_channels`.
-Ex:
+To set the light, use `ZbLight <device>,<nb_of_channels>`. Example:
 ```haskell
 ZbLight 0x1234,2
 ZbLight Kitchen_Light,1   (see ZbName)
@@ -461,9 +461,7 @@ ZbLight Kitchen_Light,1   (see ZbName)
 
 Once a light is declared, Z2T will monitor any change made to the light via Z2T or via remotes, either from a direct message or via a group message. Z2T will then send a read command to the light, between 200ms and 1000ms later, and memorize the last value.
 
-To read the last known status of a light, use `ZbLight <device>`
-
-!!! example
+To read the last known status of a light, use `ZbLight <device>`. Example:
 
 `ZbLight Kitchen_Light`
 
@@ -479,7 +477,7 @@ If your device pairs successfully with Zigbee2Tasmota but doesn't report on stan
 
 In this case you will have to use rules or an external home automation solution to parse those messages. The following section will focus only on rules to utilize the device inside Tasmota ecosystem.
 
-<!-- ### Ikea ON/OFF Switch
+### Ikea ON/OFF Switch
 `"ModelId":"TRADFRI on/off switch","Manufacturer":"IKEA of Sweden"`
 
 - Short press `O` - `0006!00`
@@ -496,7 +494,7 @@ Rule
   on ZbReceived#0x7596#0006!01 do publish cmnd/%topic%/POWER ON endon 
   on ZbReceived#0x7596#0008!01 do publish cmnd/%topic%/Dimmer - endon 
   on ZbReceived#0x7596#0008!05 do publish cmnd/%topic%/Dimmer + endon
-``` -->
+```
 
 ### Aqara Water Leak Sensor
 `"ModelId":"lumi.sensor_wleak.aq1"`
@@ -561,3 +559,208 @@ You can inspect the log output to determine whether Zigbee2Tasmota started corre
 ## Zigbee Internals
 
 If you want a more technical explanation on how all this works read [Zigbee-Internals](Zigbee-Internals.md)
+
+
+## Available commands
+### ZbInfo
+`ZbInfo` will display device info including last known status of values. Example:
+
+`ZbInfo lampDesk`
+```json
+tele/lampDesk/SENSOR = {"lampDesk":{"Device":"0xA548","Name":"lampDesk","IEEEAddr":"0x00158D0002D608BD","ModelId":"ZBT-ColorTemperature","Manufacturer":"MLI","Endpoints":[1],"Config":["O01","L01.2"],"Power":1,"Dimmer":128,"X":27667,"Y":26082,"CT":310,"ColorMode":2,"Reachable":true,"LastSeen":174,"LastSeenEpoch":1615065050,"LinkQuality":81}}
+```
+
+### ZbStatus
+`ZbStatus` will display basic device information. Example:
+
+`ZbStatus lampDesk`
+```json
+MQT: stat/zigbeeTas/RESULT = {"ZbStatus1":[{"Device":"0xA548","Name":"lampDesk"}]}
+```
+
+### ZbStatus2
+`ZbStatus2` will display a bit more status information comparing to `ZbStatus`. Example:
+
+`ZbStatus2 lampDesk`
+```json
+MQT: stat/zigbeeTas/RESULT = {"ZbStatus2":[{"Device":"0xA548","Name":"lampDesk","IEEEAddr":"0x00158D0002D608BD","ModelId":"ZBT-ColorTemperature","Manufacturer":"MLI","Endpoints":[1],"Config":["O01","L01.2"]}]}
+```
+
+### ZbRestore
+Zigbee command `ZbRestore` to restore device configuration dumped with `ZbStatus2`.
+
+*--- missing information ---*
+
+
+### ZbBindState
+Actively checks the bind state of the device. Sends the network request for state and displays results including status message and bindings. Example:
+
+`ZbBindState lampDesk`
+```json
+MQT: tele/zigbeeTas/RESULT = {"ZbBindState":{"Device":"0xA548","Name":"lampDesk","Status":0,"StatusMessage":"SUCCESS","Total":3,"Start":1,"Bindings":[{"Cluster":"0x0006","Endpoint":1,"ToDevice":"0x60A423FFFE08E221","ToEndpoint":1},{"Cluster":"0x0008","Endpoint":1,"ToDevice":"0x60A423FFFE08E221","ToEndpoint":1}]}}
+```
+
+### ZbPing
+Pings the device on the network. Example:
+
+`ZbPing lampDesk`
+```json
+MQT: tele/zigbeeTas/RESULT = {"ZbPing":{"Device":"0xA548","IEEEAddr":"0x00158D0002D608BD","Name":"lampDesk"}}
+```
+
+### ZbMap
+Creates a map of zigbee network. Example:
+
+`ZbMap`
+```json
+...
+MQT: tele/zigbeeTas/RESULT = {"ZbMap":{"Device":"0x0000","Status":0,"StatusMessage":"SUCCESS","Total":12,"Start":7,"Map":[{"Device":"0xA548","Name":"lampDesk","DeviceType":"Router","RxOnWhenIdle":true,"Relationship":"Sibling","PermitJoin":null,"Depth":15,"LinkQuality":152},{"Device":"0xCAEC","Name":"lampWorkDesk","DeviceType":"Router","RxOnWhenIdle":true,"Relationship":"Sibling","PermitJoin":null,"Depth":15,"LinkQuality":165},{"Device":"0xFA9B","Name":"lampStorage","DeviceType":"Router","RxOnWhenIdle":true,"Relationship":"Sibling","PermitJoin":null,"Depth":15,"LinkQuality":115}]}}
+...
+```
+
+### ZbOccupancy
+Command `ZbOccupancy` creates fake occupancy 0 response after predefined timeout. Usefull for motion sensors that do not report back when reason for motion is gone. Example:
+
+`ZbOccupancy motionEntrance`
+```json
+MQT: stat/zigbeeTas/RESULT = {"ZbOccupancy":90}
+MQT: stat/zigbeeTas/RESULT = {"ZbOccupancy":"Done"}
+```
+
+### ZbProbe
+Probes the zigbee device and tries to identify available endpoints. Example:
+
+`ZbProbe lampDesk`
+```json
+23:03:58 MQT: stat/zigbeeTas/RESULT = {"ZbProbe":"Done"}
+23:03:59 MQT: tele/zigbeeTas/RESULT = {"ZbPing":{"Device":"0xA548","IEEEAddr":"0x00158D0002D608BD","Name":"lampDesk"}}
+23:03:59 MQT: tele/zigbeeTas/RESULT = {"ZbState":{"Status":32,"ActiveEndpoints":["0x01","0xF2"]}}
+23:03:59 MQT: tele/lampDesk/SENSOR = {"ZbReceived":{"lampDesk":{"Device":"0xA548","Name":"lampDesk","Manufacturer":"MLI","ModelId":"ZBT-ColorTemperature","Endpoint":1,"LinkQuality":63}}}
+23:04:00 MQT: tele/zigbeeTas/RESULT = {"ZbState":{"Status":33,"Device":"0xA548","Endpoint":"0x01","ProfileId":"0x0104","DeviceId":"0x010C","DeviceVersion":1,"InClusters":["0x0000","0x0003","0x0004","0x0005","0x0006","0x0008","0x0300","0x1000"],"OutClusters":["0x0019"]}}
+23:04:02 MQT: tele/zigbeeTas/RESULT = {"ZbBind":{"Device":"0xA548","Name":"lampDesk","Status":0,"StatusMessage":"SUCCESS"}}
+23:04:04 MQT: tele/zigbeeTas/RESULT = {"ZbBind":{"Device":"0xA548","Name":"lampDesk","Status":0,"StatusMessage":"SUCCESS"}}
+23:04:06 MQT: tele/zigbeeTas/RESULT = {"ZbBind":{"Device":"0xA548","Name":"lampDesk","Status":0,"StatusMessage":"SUCCESS"}}
+23:04:08 MQT: tele/lampDesk/SENSOR = {"ZbReceived":{"lampDesk":{"Device":"0xA548","Name":"lampDesk","ConfigResponse":{},"Endpoint":1,"LinkQuality":63}}}
+23:04:10 MQT: tele/lampDesk/SENSOR = {"ZbReceived":{"lampDesk":{"Device":"0xA548","Name":"lampDesk","ConfigResponse":{},"Endpoint":1,"LinkQuality":63}}}
+23:04:12 MQT: tele/lampDesk/SENSOR = {"ZbReceived":{"lampDesk":{"Device":"0xA548","Name":"lampDesk","ConfigResponse":{"Hue":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"},"NumberOfPrimaries":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"},"Hue2":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"},"0300/000E":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"},"0300/0021":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"},"0300/0064":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"}},"Endpoint":1,"LinkQuality":65}}}
+```
+
+Note: For passive devices (buttons, motion sensors, temperature sensors, ...) probing only works during binding process. The passive devices will not respond to ZbProbe when operating in low-power mode.
+
+### SetOption66
+All zigbee ZbZNP and ZbZCL received data is published to MQTT. Example:
+
+`SetOption66 1`
+```json
+MQT: stat/zigbeeTas/RESULT = {"SetOption66":"ON"}
+CMD: zbping lampDesk
+MQT: stat/zigbeeTas/RESULT = {"ZbPing":"Done"}
+MQT: tele/zigbeeTas/SENSOR = {"ZbEZSPReceived":"3400006B"}
+MQT: tele/zigbeeTas/SENSOR = {"ZbEZSPReceived":"3F000048A5000001000000400100006B010000"}
+MQT: tele/zigbeeTas/SENSOR = {"ZbEZSPReceived":"450000000001800000400100003E94C148A5FFFF0C5500BD08D602008D150048A502"}
+MQT: tele/zigbeeTas/RESULT = {"ZbPing":{"Device":"0xA548","IEEEAddr":"0x00158D0002D608BD","Name":"lampDesk"}}
+```
+`SetOption66 0`
+```json
+MQT: stat/zigbeeTas/RESULT = {"SetOption66":"OFF"}
+CMD: zbping lampDesk
+MQT: stat/zigbeeTas/RESULT = {"ZbPing":"Done"}
+MQT: tele/zigbeeTas/RESULT = {"ZbPing":{"Device":"0xA548","IEEEAddr":"0x00158D0002D608BD","Name":"lampDesk"}}
+```
+
+### SetOption83
+`ZbNameKey` is a synonym for [`SetOption83`](Commands.md#setoption83).
+The command will replace the short device ID in the MQTT message with device name. Example:
+
+`SetOption83 0`
+```json
+tele/buttonDesk/SENSOR {"0x306A":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":71}}
+```
+`SetOption83 1`
+```json
+tele/buttonDesk/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":71}}
+```
+
+### SetOption89 (ZbDeviceTopic)
+`ZbDeviceTopic` is a synonym for [`SetOption89`](Commands.md#setoption89).
+
+The command changes the topic of the resulting MQTT message to include the device name. Example:
+
+`SetOption89 0`
+```json
+tele/zigbeeTas/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":63}}
+```
+`SetOption89 1`
+```json
+tele/buttonDesk/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":52}}
+```
+
+### SetOption100 (ZbNoPrefix)
+`ZbNoPrefix` is a synonym for [`SetOption100`](Commands.md#setoption100).
+
+Command SetOption100 0/1 to remove Zigbee ZbReceived value from {"ZbReceived":{xxx:yyy}} JSON message. Example:
+
+`SetOption100 0`
+```json
+MQT: tele/buttonDesk/SENSOR = {"ZbReceived":{"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":73}}}
+```
+`SetOption100 1`
+```json
+MQT: tele/buttonDesk/SENSOR = {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":71}}
+```
+
+### SetOption101 (ZbEndpointSuffix)
+`ZbEndpointSuffix` is a synonym for [`SetOption101`](Commands.md#setoption101).
+
+Command SetOption101 0/1 to add the Zigbee source endpoint as suffix to attributes, ex Power3 instead of Power if sent from endpoint 3. Example:
+
+`SetOption101 0`
+```json
+tele/buttonDesk/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power":1,"Endpoint":1,"LinkQuality":65}}
+```
+`SetOption101 1`
+```json
+tele/buttonDesk/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":60}}
+```
+
+### SetOption112 (ZbNameTopic)
+`ZbNameTopic` is a synonym for [`SetOption112`](Commands.md#setoption112).
+
+Command `SetOption112` modifies the MQTT topic to switch from tasmota device name and zigbee device short ID to zigbee device name. Example:
+
+`SetOption112 0`
+```json
+tele/zigbeeTas/306A/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":42}}
+```
+
+`SetOption112 1`
+```json
+tele/buttonDesk/SENSOR {"buttonDesk":{"Device":"0x306A","Name":"buttonDesk","0006!01":"","Power1":1,"Endpoint":1,"LinkQuality":37}}
+```
+
+### SetOption116
+Command `SetOption116 1` to disable auto-query of zigbee light devices (avoids network storms with large groups).
+
+
+----------------
+
+## To be document
+`ZbLeave`
+
+ZbRestore (#9641)
+
+ZbData
+
+ZbSend Config and ReadConfig
+
+ZbConfig
+
+Zigbee command ZbUnbind
+
+ZbBind (experimental) and bug fixes
+
+`ZbNoAutoBind` is a synonym for [`SetOption110`](Commands.md#setoption110)
+
+Command SetOption118 1 to move ZbReceived from JSON message and into the subtopic replacing "SENSOR" default (#10353) *-- no relevant difference visible*
+
+Command SetOption119 1 to remove the device addr from json payload, can be used with zb_topic_fname where the addr is already known from the topic (#10355) *-- no relevant difference visible*


### PR DESCRIPTION
I updated a few commands in Zigbee documentation.
My aim was to reverse-engineer the release changelog to be a bit more up to date.
Unfortunately, I don't understand all the commands and for some of the SO I cannot see a difference in output. Perhaps someone more skilled can help here...