### PR TITLE
Update TSL2561.md

### DIFF
--- a/docs/TSL2561.md
+++ b/docs/TSL2561.md
@@ -1,10 +1,8 @@
 # TSL2561 light sensor
 
-!!! info "This feature is included only in tasmota-sensors.bin" 
-
-Otherwise you must [compile your build](Compile-your-build.md). Add the following to `user_config_override.h`:
+You must [compile your build](Compile-your-build.md). Add the following to `user_config_override.h`:
 ```
-#ifndef USE_VEML6070
+#ifndef USE_TSL2561
 #define USE_TSL2561         // Enable TSL2561 sensor (I2C address 0x29, 0x39 or 0x49) (+2k3 code)
 #endif
 ```


### PR DESCRIPTION
Update to confirm `USE_TSL2561` no longer in sensors, and fix copy/paste error.