### PR TITLE
Correct Home Assistant light configuration example

### DIFF
--- a/docs/Home-Assistant.md
+++ b/docs/Home-Assistant.md
@@ -731,7 +731,7 @@ light:
   - platform: mqtt
     name: "Pat Ceiling Light"
     state_topic: "tele/ifan02/STATE"
-    value_template: "{{ value_json.POWER }}"
+    state_value_template: "{{ value_json.POWER }}"
     command_topic: "cmnd/ifan02/POWER"
     availability_topic: "tele/ifan02/LWT"
     qos: 1


### PR DESCRIPTION
Correct Home Assistant light configuration example, support for `value_template` will be removed in Home Assistant 2021.10