### PR TITLE
openHAB: Update to changed info topics content

### DIFF
--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -61,11 +61,11 @@ Thing mqtt:topic:tasmota:tasmota_TH "Light_TH" (mqtt:broker:myMQTTBroker) {
         Type switch : Reachable    [stateTopic="tele/tasmota_TH/LWT",     transformationPattern="MAP:tasmota-reachable.map"]
 
         // Diagnostics: Define specific for what you really need on a regular basis, use standalone MQTT client for troubleshooting
-        Type string : RestartReason [stateTopic="tele/tasmota_TH/INFO3", transformationPattern="JSONPATH:$.RestartReason"]
+        Type string : RestartReason [stateTopic="tele/tasmota_TH/INFO3", transformationPattern="JSONPATH:$.Info3.RestartReason"]
         // old one, have to query it
         Type string : Version2      [stateTopic="stat/tasmota_TH/STATUS2", transformationPattern="JSONPATH:$.StatusFWR.Version"]
         // new one - comes for free at startup
-        Type string : Version       [stateTopic="tele/tasmota_TH/INFO1", transformationPattern="JSONPATH:$.Version"]
+        Type string : Version       [stateTopic="tele/tasmota_TH/INFO1", transformationPattern="JSONPATH:$.Info1.Version"]
         Type number : RSSI          [stateTopic="tele/tasmota_TH/STATE", transformationPattern="JSONPATH:$.Wifi.RSSI"]
         Type string : WifiDowntime  [stateTopic="tele/tasmota_TH/STATE", transformationPattern="JSONPATH:$.Wifi.Downtime"]
         Type number : LoadAvg       [stateTopic="tele/tasmota_TH/STATE", transformationPattern="JSONPATH:$.LoadAvg"]


### PR DESCRIPTION
Somewhere between v9.3.0 and v9.5.0 the content of used INFO1 and INFO3 topics changed. Change example to make it work again