### PR TITLE
Update TM163x.md

### DIFF
--- a/docs/TM163x.md
+++ b/docs/TM163x.md
@@ -14,6 +14,13 @@ To use this feature (i.e., if you're not using _tasmota*-display.bin_ precompile
 #define USE_DISPLAY_TM1637
 #endif
 ```
+In case you want MAX7219 also add:
+```
+#ifndef USE_DISPLAY_MAX7219
+#define USE_DISPLAY_MAX7219
+#endif
+```
+To get the config options for GPIO-Pins displayed
 ----  
 
 


### PR DESCRIPTION
Hi, I found out that my tasmota.bin I compiled with TLS MQTT and DISPLAY support for TC1637 was missing the possibility to configure the GPIO Pins with MAX7219 (CLK,DIN,CS) values. 
Digging trough the source code a bit I found the USE_DISPLAY_MAX7219 parameter, adding this to my user_config_override.h did the trick