### PR TITLE
Update SetOption0 with mentioning SaveData

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -413,7 +413,7 @@ DevGroupStatus<x\><a class="cmnd" id="devgroupstatus"></a>|Show the status of de
 
 Command|Parameters
 :---:|:---
-SetOption0<a class="cmnd" id="setoption0"></a>|Save power state and use after restart (=SaveState)<BR> `0` = disable<BR> `1` = enable *(default)*
+SetOption0<a class="cmnd" id="setoption0"></a>|Save power state and use after restart (=SaveState)<BR> `0` = disable (see note below)<BR> `1` = enable *(default)*<BR>Note: Power state means on/off state of eg. relays, lights, but other parameters like color, color temperature, brightness, dimmer, etc. are still saved when changed. To disable saving other parameters see [`SaveData`](#savedata).
 SetOption1<a class="cmnd" id="setoption1"></a>|Set [button multipress](Buttons-and-Switches#multi-press-functions) mode to<BR> `0` = allow all button actions *(default)*<BR> `1` = restrict to single to penta press and hold actions (i.e., disable inadvertent reset due to long press)
 SetOption3<a class="cmnd" id="setoption3"></a>|[MQTT](MQTT) <BR>`0` = disable MQTT<BR> `1` = enable MQTT *(default)*
 SetOption4<a class="cmnd" id="setoption4"></a>|Return MQTT response as<BR> `0` = RESULT topic *(default)*<BR> `1` = %COMMAND% topic


### PR DESCRIPTION
It's not mentioned, that changes to other "power state" parameters, like color, brightness, dimmer etc. is still written to flash, causing confusion (https://github.com/arendst/Tasmota/issues/1562, https://github.com/arendst/Tasmota/issues/5639).