### PR TITLE
Fixed RF-Transceiver typos.

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -546,7 +546,7 @@ RfRaw<a class="cmnd" id="rfraw"></a>|**This command only works when the firmware
 RfSync<a class="cmnd" id="rfsync"></a>|`1` = reset start sync pulse time to 8470 microseconds<BR>`2..32767` = set start sync pulse time in microseconds<BR>`#2..#7FFF` = set start sync pulse time in hexadecimal microseconds
 See also|[`SetOption28`](#setoption28) - Set RF received data format
 
-### RF Transciever
+### RF Transceiver
 Command|Parameters
 :---|:---
 RFsend<a id="rfsend"></a>|`<value>` = code decimal or JSON. Data value is required and can be decimal or hexadecimal (using the 0x prefix), other values are optional.<BR><BR>_JSON_<BR>`{"Data":"<value>","Bits":<value>,"Protocol":<value>,"Pulse":<value>}`<BR>`"Data":"<value>"` = hexadecimal code<BR>`"Bits":<value>` = required number of data bits _(default = `24`)_<BR>`"Protocol":<value>` = protocol number _(default = `1`)_<BR>`"Repeat":<value>` = repeat value _(default = `10`)_<BR>`"Pulse":<value>` = pulse value _(`350` = default for protocol 1)_<BR>&emsp;e.g., `RFsend {"Data":"0x7028DC","Bits":24,"Protocol":1,"Pulse":238}`<BR><BR>_Decimal_<BR>`data, bits, protocol, repeat, pulse` <BR>&emsp;e.g., `RFsend 7350492, 24, 1, 10, 238` or `RFsend 0x7028DC, 24, 1, 10, 238`

--- a/docs/RF-Transceiver.md
+++ b/docs/RF-Transceiver.md
@@ -16,7 +16,7 @@ Some of officially supported modules by rc-switch are:
 This guide was created using STX882 RF transmitter which also works without issues.
 
 ### Wiring
-| RF   | ESP266 |
+| RF   | ESP8266 |
 |---|---|
 |data   |GPIOx   |
 |+   | 3.3v/5v  |
@@ -27,7 +27,7 @@ In the **_Configuration -> Configure Module_** page assign:
 
 - GPIOx to `RFSend (105)`   
 
-See [RF commands](Commands.md#rf-transciever) for use. 
+See [RF commands](Commands.md#rf-transceiver) for use. 
 
 ## RF Receiver
 ![](_media/peripherals/SRX882.jpg)
@@ -39,7 +39,7 @@ RF receiver is used to capture RF codes. Those codes can be sent using [`RFSend`
 This guide is using SRX882 RF receiver module with a helical antenna. 
 
 ### Wiring
-| SRX882   | ESP266 |
+| SRX882   | ESP8266 |
 |---|---|
 |Data   |GPIOx   |
 |VCC   | 5v  |

--- a/docs/Supported-Peripherals.md
+++ b/docs/Supported-Peripherals.md
@@ -72,7 +72,7 @@ Name|Description
 [**PZEM-004<BR>PZEM-016**](PZEM-0XX) | Energy Monitor (serial) 
 [**RCWL-0516**](RCWL-0516) |  Microwave Radar Presence detection
 [**RDM6300**](RDM6300) | 125Khz RFID Module
-[**RF Transciever**](RF-Transciever) | IR receiver and/or transmitter
+[**RF Transceiver**](RF-Transceiver) | IR receiver and/or transmitter
 **RX-4M50RR30SF<BR>RX-AM8SF** | RF Sensor receiver (gpio)
 **SCD30** | CO<sub>2</sub> Sensor (I^2^C)
 **Eastron SDM72** | Modbus Energy Meter (serial)


### PR DESCRIPTION
Changed "transciever" for "transceiver" which is the correct spelling.