### PR TITLE
Jst

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -1706,7 +1706,7 @@ Activate dimmer mode with `Switchmode 11` and shorten long press time to 1 secon
 A short press of the switch sends a `TOGGLE` message to toggle the dimmer. A long press sends repeated `INC_DEC` messages to increment the dimmer. If a second press of the switch follows the first press a `INV` message is sent to invert the function from increment to decrement and repeated `INC_DEC` messages are sent to decrement the dimmer. After releasing the switch a timeout message `CLEAR` resets the automation
 
 ```haskell
-Backlog SwitchMode 11; SetOption32 10;
+Backlog SwitchMode 11; SetOption32 10; Rule1 1;
 
 Rule1 
 on system#boot do var1 + ENDON
@@ -1715,8 +1715,6 @@ on switch1#state=4 do DIMMER %var1% ENDON
 on switch1#state=6 do event upordown=%var1% ENDON
 on event#upordown=+ do var1 - ENDON
 on event#upordown=- do var1 + ENDON
-
-Rule1 1
 ```
 Notice we use `Rule` which edits `Rule1` rule set. They can be used interchangeably.
 


### PR DESCRIPTION
Dimmer with one switch doesn't have to use MQTT. Also dimming is more logical when direction is changed every time the button is released (like other dimmers on the market like shelly dimmer 1 or moeshouse wifidimmers). The ; after setoption32 10 is mandatory, otherwise the rule1 won't be saved upon copy paste of whole block  (see arendst/Tasmota#10202).