### PR TITLE
Add subscribe example

### DIFF
--- a/docs/Subscribe-&-Unsubscribe.md
+++ b/docs/Subscribe-&-Unsubscribe.md
@@ -21,22 +21,7 @@ You can set up a rule with `ON EVENT#<event_name> DO ... ENDON` to do what you w
 
 For example, if you have a Tasmota based thermostat and multiple temperature sensors in different locations, usually you have to set up a home automation system like Domoticz to control the thermostat. Right now, with this new feature, you can write a rule to do this.  
 
-**Examples:**  
-```console
-Rule1
-  ON mqtt#connected DO Subscribe BkLight, stat/%topic%/POWER ENDON
-  ON Event#BkLight=ON DO <command> ENDON
-```
-```console
-Rule1
-  ON mqtt#connected DO Subscribe DnTemp, stat/%topic%/SENSOR, DS18B20.Temperature ENDON
-  ON Event#DnTemp>=21 DO <command> ENDON
-
-where the MQTT message payload is `{"Time":"2017-02-16T10:13:52", "DS18B20":{"Temperature":20.6}}`
-```
-```console
-Rule1
-**Examples:**  
+### Examples
 ```console
 Rule1
   ON mqtt#connected DO Subscribe BkLight, stat/other-device-topic/POWER ENDON
@@ -46,19 +31,19 @@ Rule1
 Rule1
   ON mqtt#connected DO Subscribe DnTemp, stat/other-device-topic/SENSOR, DS18B20.Temperature ENDON
   ON Event#DnTemp>=21 DO <command> ENDON
-
-where the MQTT message payload is `{"Time":"2017-02-16T10:13:52", "DS18B20":{"Temperature":20.6}}`
 ```
+where the MQTT message payload is `{"Time":"2017-02-16T10:13:52", "DS18B20":{"Temperature":20.6}}`
 ```console
 Rule1
   ON mqtt#connected DO Subscribe DnTemp, stat/other-device-topic/SENSOR, DS18B20.Temperature ENDON
-ON Event#DnTemp DO TempMeasuredSet %value% ENDON
-
-will allow a thermostat to subscribe to a temperature sensor on another Tasmota device
   ON Event#DnTemp DO TempMeasuredSet %value% ENDON
-
-will allow a thermostat to subscribe to a temperature sensor on another Tasmota device
 ```
+will allow a thermostat to subscribe to a temperature sensor on another Tasmota device
+```console
+  ON Event#DnTemp DO TempMeasuredSet %value% ENDON
+```
+Will allow a thermostat to subscribe to a temperature sensor on another Tasmota device
+
 ## Unsubscribe
 Unsubscribe from topics which were subscribed to using the [`Subscribe`](#subscribe) command.  
 

--- a/docs/Subscribe-&-Unsubscribe.md
+++ b/docs/Subscribe-&-Unsubscribe.md
@@ -36,7 +36,25 @@ where the MQTT message payload is `{"Time":"2017-02-16T10:13:52", "DS18B20":{"Te
 ```
 ```console
 Rule1
-  ON mqtt#connected DO Subscribe DnTemp, stat/%topic%/SENSOR, DS18B20.Temperature ENDON
+**Examples:**  
+```console
+Rule1
+  ON mqtt#connected DO Subscribe BkLight, stat/other-device-topic/POWER ENDON
+  ON Event#BkLight=ON DO <command> ENDON
+```
+```console
+Rule1
+  ON mqtt#connected DO Subscribe DnTemp, stat/other-device-topic/SENSOR, DS18B20.Temperature ENDON
+  ON Event#DnTemp>=21 DO <command> ENDON
+
+where the MQTT message payload is `{"Time":"2017-02-16T10:13:52", "DS18B20":{"Temperature":20.6}}`
+```
+```console
+Rule1
+  ON mqtt#connected DO Subscribe DnTemp, stat/other-device-topic/SENSOR, DS18B20.Temperature ENDON
+ON Event#DnTemp DO TempMeasuredSet %value% ENDON
+
+will allow a thermostat to subscribe to a temperature sensor on another Tasmota device
   ON Event#DnTemp DO TempMeasuredSet %value% ENDON
 
 will allow a thermostat to subscribe to a temperature sensor on another Tasmota device

--- a/docs/Subscribe-&-Unsubscribe.md
+++ b/docs/Subscribe-&-Unsubscribe.md
@@ -34,7 +34,13 @@ Rule1
 
 where the MQTT message payload is `{"Time":"2017-02-16T10:13:52", "DS18B20":{"Temperature":20.6}}`
 ```
+```console
+Rule1
+  ON mqtt#connected DO Subscribe DnTemp, stat/%topic%/SENSOR, DS18B20.Temperature ENDON
+  ON Event#DnTemp DO TempMeasuredSet %value% ENDON
 
+will allow a thermostat to subscribe to a temperature sensor on another Tasmota device
+```
 ## Unsubscribe
 Unsubscribe from topics which were subscribed to using the [`Subscribe`](#subscribe) command.  
 


### PR DESCRIPTION
Added an example of passing a numerical value to a command. There are clues elsewhere in the docs but it would be quicker to show it here.