### PR TITLE
fix typos

### DIFF
--- a/docs/NeoPool.md
+++ b/docs/NeoPool.md
@@ -27,7 +27,7 @@ The sensor shows the most of parameters such as the built-in display:
 ![](_media/xsns_83_neopool_s.png)
 
 Basic commands to control filtration and light are implemented.
-However, the sensor provides commands to read and write the NeoPool controller Modbus register, means that everyone has the option of implementing their own commands via their home automation system or using the Tasmota build-in possibilities with [Rules](Commands/#rules) and [Backlog](Commands/#the-power-of-backlog).
+However, the sensor provides commands to read and write the NeoPool controller Modbus register, means that everyone has the option of implementing their own commands via their home automation system or using the Tasmota build-in possibilities with [Rules](Commands#rules) and [Backlog](Commands#the-power-of-backlog).
 
 ## Configuration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,7 +226,7 @@ nav:
     - PZEM-0XX.md
     - RCWL-0516.md
     - RDM6300.md
-    - RF-Transciever.md
+    - RF-Transceiver.md
     - SDS011.md
     - SHT30.md
     - SK6812.md


### PR DESCRIPTION
fixes 
```
WARNING  -  A relative path to 'RF-Transciever.md' is included in the 'nav' configuration, which is not found in the documentation files
WARNING  -  Documentation file 'NeoPool.md' contains a link to 'Commands\.md' which is not found in the documentation files.
WARNING  -  Documentation file 'NeoPool.md' contains a link to 'Commands\.md' which is not found in the documentation files.
```