### PR TITLE
Clarify DisplayTextNC command, add example

### DIFF
--- a/docs/TM163x.md
+++ b/docs/TM163x.md
@@ -204,7 +204,7 @@ DisplayFloat | Clears and then displays float (with decimal point)  command e.g.
 DisplayFloatNC | Displays float (with decimal point) as above, but without clearing first. command e.g., "DisplayFloatNC 12.34" | same as above
 DisplayRaw | Takes upto `NUM_DIGITS` comma-separated integers (0-255) and displays raw segments. <br> Each number represents a 7-segment digit. Each 8-bit number represents individual segments of a digit. <br> Segment a=1, b=2, c=4, d=8, e=16, f=32, g=64 and h (decimal point)=128.<br> To turn on all segments, the number would be 1+2+4+8+16+32+64+128 = 255<br> For example, the command `DisplayRaw 0, 2, 255, 255` would display:<br> ![8.8.](_media/peripherals/TM1637-8.8.jpg) | `position`, `length`,  `num1` [, `num2`[, `num3`[, `num4`[, ...upto `NUM_DIGITS` numbers]]...]
 DisplayText | Clears and then displays basic text.  Command e.g., `DisplayText a.b12` <br> Control `length` and `position` of the displayed text. <br> `length` can be `1` to `NUM_DIGITS` , <br> `position` can be `0` (left-most) to `NUM_DIGITS-1` (right-most) <br><br>  A caret(`^`) symbol in the text input is dispayed as the degrees(`°`) symbol. This is useful for displaying Temperature (or angle)! <br> For example, the command `DisplayText 22.5^` will display:<br> ![22.5d](_media/peripherals/TM1637-22.5d.jpg)  | `text`[, `position`[, `length`]]
-DisplayTextNC | Clears first, then displays text. Usage is same as above. | same as above
+DisplayTextNC | Displays text without first clearing the display. Usage is same as above. | same as above
 DisplayScrollText | Displays scrolling text, upto 50 characters. <br>If `num_iterations` is not specified, it scrolls indefinitely, until another *Display-* command is issued. Optionally, specifying `num_iterations` causes the scrolling to stop after the specified number of iterations.<br>Command examples: <br>`DisplayScrollText tasmota is awesome`   -- causes indefinite scrolling<br>`DisplayScrollText tasmota is awesome, 5`   -- causes scrolling to stop after 5 iterations| `text` [, `num_iterations`]
 DisplayScrollDelay | Sets the speed of text scroll. Smaller delay = faster scrolling. | 0 to 15
 DisplayLevel | Display a horizontal bar graph. Command e.g., `DisplayLevel 50` will display:<br> ![](_media/peripherals/TM1637-level.jpg)<br> | 0 to 100
@@ -222,6 +222,12 @@ For example, a simple digital thermometer can be implemented by connecting a **D
 Rule1
 ON Tele-AM2301#Temperature DO DisplayText %value%^ ENDON
 ```
+Another example, using a **MAX7219** and a **SHT3X** temp/humidity sensor, with value comparison so dispaytext only fires when the value changes. The first four digits display the temperature and the second four digits dispay the humidity. The DisplayTextNC command is used to leave unused digits illuminated, so both numbers can be independently updated.
+```pkkrusty
+Rule1
+on sht3x#Temperature!=%var1% do backlog displaytextnc %value%^;var1 %value% endon on sht3x#Humidity!=%var2% do backlog displaytextnc %value%h,4;var2 %value% endon on system#init do power 1 endon
+```
+
 
 ## TM1637 Images
 


### PR DESCRIPTION
DisplayTextNC command wrongly described as clearing the display. Also added an example using it.