### PR TITLE
Update power toggle mapping info

### DIFF
--- a/docs/TM163x.md
+++ b/docs/TM163x.md
@@ -139,7 +139,7 @@ For example, if x=0 and y=2, z=4 then the module configuration would look like t
 
 ### Initial Setup
 
-The power toggle button in webUI turns the display on or off. However, if there are additional relays defined, resulting in multiple power toggle buttons in WebUI, display power will map to the last button. Thus, it is necessary to define a virtual relay as the last.
+The power toggle button in webUI turns the display on or off. However, if there are additional relays defined, resulting in multiple power toggle buttons in WebUI, display power will create and map to the last button. Thus, it is necessary to ensure that relays are numbered from 1, otherwise a conflict will occur with the display power.
 
 ### DisplayModel
 

--- a/docs/TM163x.md
+++ b/docs/TM163x.md
@@ -139,7 +139,7 @@ For example, if x=0 and y=2, z=4 then the module configuration would look like t
 
 ### Initial Setup
 
-The power toggle button in webUI turns the display on or off. 
+The power toggle button in webUI turns the display on or off. However, if there are additional relays defined, resulting in multiple power toggle buttons in WebUI, display power will map to the last button. Thus, it is necessary to define a virtual relay as the last.
 
 ### DisplayModel
 


### PR DESCRIPTION
When relays are on the same board as a TM1637, the power toggle will map to whatever the last defined power button is in the WebUI, so turning the relay on and off will also turn your display on and off, and changing Displaydimmer from <12 to >=12 will turn the relay off and on as well.  Thus a final virtual relay needs to be defined to avoid conflict.