### PR TITLE
Refer am2301 as compatible with aht20

### DIFF
--- a/docs/AHT1x.md
+++ b/docs/AHT1x.md
@@ -1,21 +1,30 @@
-# AHT1x temperature and humidity sensor
+# AHT1x/AHT2x and compatible temperature and humidity sensor
 !!! failure "This feature is not included in precompiled binaries"  
 
-To use it you must [compile your build](Compile-your-build). Add the following to `user_config_override.h`:
+To use it you must [compile your build](Compile-your-build). Add the following to `user_config_override.h` to add support for AHT10 or AHT15:
 ```
 #ifndef USE_AHT1x
-#define USE_AHT1x       // [I2cDriver43] Enable AHT10/15 humidity and temperature sensor (I2C address 0x38) (+0k8 code)
+#define USE_AHT1x       // [I2cDriver43] Enable AHT10/15 humidity and temperature sensor (I2C address 0x38 or 0x39)
 #endif
 ```
+or those lines for AHT20 or AM2301B:
+```
+#ifndef USE_AHT2x
+#define USE_AHT2x       Enable AHT20 instead of AHT1x humidity and temperature sensor (I2C address 0x38)
+#endif
+```
+
 ----
 
 AHT10 or AH15 are an I<sup>2</sup>C temperature and humidity sensor.
+AHT20 or AM2301B are upgraded versions.
 
 ## Configuration
 
 !!! failure "This sensor is incompatible with other I^2^C devices on I^2^C bus"
     Sensor datasheet implicitly says:
     **Only a single** AHT10 can be connected to the I^2^C bus and no other I^2^C devices can be connected.
+    The AHT20/AM2301B do not suffer from this problem.
 
 ### Wiring
 | AHT1x   | ESP8266 |

--- a/docs/AM2301.md
+++ b/docs/AM2301.md
@@ -6,6 +6,8 @@ AM2301 driver supports [AM2301 (DHT21)](http://www.haoyuelectronics.com/Attachme
 
 **This driver is ONLY for _single wire_ implementations of the sensor.**
 
+For AM2301B I^2^C model, please refer to [AHT1x/AHT2x](AHT1x) driver.
+
 ## Configuration
 
 ### Wiring

--- a/docs/Supported-Peripherals.md
+++ b/docs/Supported-Peripherals.md
@@ -6,8 +6,9 @@ Name|Description|Connection
 [**A4988**](A4988-Stepper-Motor-Controller)| Stepper Motor Controller 
 [**ADC**](ADC) | Analog input over A0 pin | analog
 **ADS111x** | A/D Converter | I^2^C
-[**AHT1x**](AHT1x.md)<BR>**AHT2x** | Asair AHT10/AHT15/AHT20/AHT21/AHT25 Temperature and Humidity Sensor | I^2^C
+[**AHT1x**](AHT1x.md)<BR>**AHT2x** | Asair AHT10/AHT15/AHT20/AHT21/AHT25/AM2301B Temperature and Humidity Sensor | I^2^C
 [**AM2301 / DHT21 <BR>AM2302 / DHT22<BR>AM2321**](AM2301) | Temperature and Humidity Sensor | gpio
+[**AM2301B**](AHT1x) | Temperature and Humidity Sensor<br><i>Use same driver as AHT2X</i>| I^2^C
 **AM2320** | Temperature and Humidity Sensor | gpio
 **AS608** | AS608 Optical and R503 Capacitive Fingerprint Sensor| serial
 [**AS3935**](AS3935) | Franklin Lightning Sensor| serial


### PR DESCRIPTION
As discussed here https://github.com/arendst/Tasmota/discussions/14713
AM2301B is I2C device compatible with the same driver as AHT20