### PR TITLE
Correct pinout chart on HRG15.md

### DIFF
--- a/docs/HRG15.md
+++ b/docs/HRG15.md
@@ -21,7 +21,7 @@ Find out more on the [manufacturer's website](https://rainsensors.com/products/r
 | HRG15 | ESP8266
 |   ---|    ---
 |GND (1)  | GND
-|VCC (8)   | 3.3V 
+|V+ 3.3V (8)   | 3.3V 
 |RS232 Out (4) | GPIOx
 |RS232 In (5)  | GPIOy
 


### PR DESCRIPTION
While Vcc is the prefered method of powering the device, it requires 5v. Since the Esp8266 does not have a 5V pin the 3.3V can be used. However, 3.3v has the potential to effect sensor data because the regulator is bypassed. 