### PR TITLE
fix HA example for blinds

### DIFF
--- a/docs/Home-Assistant.md
+++ b/docs/Home-Assistant.md
@@ -903,7 +903,7 @@ cover:
     payload_available: "Online"
     payload_not_available: "Offline"
     position_topic: "stat/%topic%/RESULT"
-    value_template: >
+    position_template: >
       {% if ('Shutter1' in value_json) and ('Position' in value_json.Shutter1) %}
         {{ value_json.Shutter1.Position }}
       {% else %}


### PR DESCRIPTION
The old examples fails with this error message:

```
2022-02-14 14:25:44 ERROR (MainThread) [homeassistant.config] Invalid config for [cover.mqtt]: 'value_template' must be set together with 'state_topic'.. Got OrderedDict([('platform', 'mqtt'), ('name', 'Rollershutter XXXX'), ('position_topic', 'stat/tasmota_XXXX/RESULT'), ('value_template', "{% if ('Shutter1' in value_json) and ('Position' in value_json.Shutter1) %}\n  {{ value_json.Shutter1.Position }}\n{% else %}\n  {% if is_state('cover.Rollershutter_XXXX', 'unknown') %}\n    50\n  {% else %}\n    {{ state_attr('cover.Rollershutter_XXXX','current_position') }}\n  {% endif %}\n{% endif %}\n"), ('position_open', 100), ('position_closed', .... (See /config/cover.yaml, line 2). Please check the docs at https://www.home-assistant.io/integrations/mqtt
```