### PR TITLE
OpenHAB add availabilityTopic

### DIFF
--- a/docs/openHAB.md
+++ b/docs/openHAB.md
@@ -45,7 +45,7 @@ Bridge mqtt:broker:myMQTTBroker "My only one and best MQTT server"
     clientID="myopenHABMQTTClient"
 ]
 
-Thing mqtt:topic:tasmota:tasmota_TH "Light_TH" (mqtt:broker:myMQTTBroker) {
+Thing mqtt:topic:tasmota:tasmota_TH "Light_TH" (mqtt:broker:myMQTTBroker) [ availabilityTopic="tele/tasmota_TH/LWT", payloadAvailable="Online", payloadNotAvailable="Offline" ] {
     Channels:
         // Sonoff Basic / Sonoff S20 Smart Socket (Read and switch on-state)
         Type switch : PowerSwitch  [stateTopic="stat/tasmota_TH/POWER",   commandTopic="cmnd/tasmota_TH/POWER", on="ON", off="OFF"]
@@ -72,7 +72,6 @@ Thing mqtt:topic:tasmota:tasmota_TH "Light_TH" (mqtt:broker:myMQTTBroker) {
         Type number : Uptime        [stateTopic="tele/tasmota_TH/STATE", transformationPattern="JSONPATH:$.UptimeSec"]
         Type string : Result        [stateTopic="stat/tasmota_TH/RESULT"]
 }
-
 ```
 
 **.items File:**


### PR DESCRIPTION
Adding the optional `availabilityTopic` check for OpenHAB and tasmota.

There is a PR to add a description for this to the OpenHAB documentation:
- https://github.com/openhab/openhab-addons/pull/12158

There is a old discussion on this in the openhab forum:
- https://community.openhab.org/t/mqtt-lwt-things-definition-availability-topic/103065