### PR TITLE
Add `USE_VL53L1X`

### DIFF
--- a/docs/Firmware-Builds.md
+++ b/docs/Firmware-Builds.md
@@ -158,6 +158,7 @@ m = minimal, l = lite, t = tasmota, k = knx, s = sensors, i = ir, d = display
 | USE_SPS30             | - | - | - / - | - | - | - | - |
 | USE_ADE7953           | - | - | x / x | x | x | - | x |
 | USE_VL53L0X           | - | - | - / x | - | x | - | - |
+| USE_VL53L1X           | - | - | - / - | - | - | - | - |
 | USE_MLX90614          | - | - | - / - | - | - | - | - |
 | USE_CHIRP             | - | - | - / - | - | - | - | - |
 | USE_PAJ7620           | - | - | - / - | - | - | - | - |


### PR DESCRIPTION
Adds a `USE_VL53L1X` column to `Firmware-Builds.md`