### PR TITLE
Fix incorrect formatting of commands page

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -25,19 +25,19 @@ In commands with `x..y` value parameters use a number from `x` to `y` range.
 
 When a command mentions resetting to *"firmware default"* it means the setting will revert to the one in the flashed binary file. If you used `user_config_override.h` at compile time it will revert to those.
 
-!!! note:
+!!! note
     All commands are standard in the form: `COMMAND`<`INDEX`> `DATA` It has only one `SPACE` between `INDEX` and `DATA`. (There is no command in Tasmota that allows the `=` sign)
     
-!!! example:
+!!! example
     Set networking IP (XXX.XXX.XXX.XXX) addresses using the command `IPAddress<x>`: `IPAddress1 192.168.1.123`
     
 The `=` sign (It can be understood as the sign `:`) is used only for meaning explanation reference: `IPAddress1 = set device IP address`
 
-!!! note:
+!!! note
     Beside results initiated by a command (synchronous) you can get asynchronous results initiated by rule trigger, telemetry event, commands from other source or changed device values.
     Simply put, other messages may precede messages published as a result of your commands.
 
-!!! example:
+!!! example
     A `tele/%topic%/STATUS` message (sent every 300 seconds by default) may appear exactly after you issue `Power off` command and before you receive `stat/%topic%/RESULT = {"POWER":"OFF"}` message.
 
 


### PR DESCRIPTION
The mkdoc admonition format is incorrect on [this page](https://tasmota.github.io/docs/Commands/)

The extra `:` on the admonition is confusing mkdoc, This _should_ fix it (though I don't have a way to test it)

<img width="800" alt="Screen Shot 2022-04-16 at 10 37 34 AM" src="https://user-images.githubusercontent.com/242382/163683640-663d7134-9103-4830-9c8a-47a46e67ad24.png">

