### PR TITLE
Correct name

### DIFF
--- a/docs/OpenHASP.md
+++ b/docs/OpenHASP.md
@@ -2,9 +2,9 @@
 
 !!! info "This feature is experimental"
 
-Tasmota is happy to support OpenHASP format, which allows to describe rich graphics interfaces using simple JSON templates. OpenHASP support leverages the power of [LVGL](https://tasmota.github.io/docs/LVGL/) and the [Berry language](https://tasmota.github.io/docs/Berry/), but doesn't need to code nor learn the LVGL API.
+Tasmota is happy to support openHASP format, which allows to describe rich graphics interfaces using simple JSON templates. OpenHASP support leverages the power of [LVGL](https://tasmota.github.io/docs/LVGL/) and the [Berry language](https://tasmota.github.io/docs/Berry/), but doesn't need to code nor learn the LVGL API.
 
-This feature is heavily inspired from @franvoie's [OpenHASP project](https://github.com/HASwitchPlate/openHASP).
+This feature is heavily inspired from @fvanroie's [openHASP project](https://github.com/HASwitchPlate/openHASP).
 
 ## Minimal requirements
 


### PR DESCRIPTION
I fixed a typo in my Github handle. Also note that openHASP project has 'open' in lowercare and 'HASP' in uppercase

Reading through the page there seems to be no clear distinction between the *openHASP JSONL format*, the tasmota *berry module* and the *openHASP project*. I think these should not be used interchangeably. I'm afraid that calling the openhasp.tapp module in tasmota will lead to confusion for the users between the projects.

For example:
> **Hardware**: OpenHASP is supported on all ESP32 variants, and requires a display configured with universal display (using `display.ini` or `autoconf`). You should see a splash screen at startup.

> Currently **PSRAM** is required to run OpenHASP. 

> OpenHASP automatically loads the template from a file named `pages.jsonl`.

> ## OpenHASP reference

> Each OpenHASP widget is mapped to a global variable of name `p<x>b<y>`.

> OpenHASP parses all lines from the file `pages.jsonl`. You can dynamically add new objects as JSON with `openhasp.parse(<json>)`.

> Internally OpenHASP pages are implemented with LVGL screens, i.e. a parent object.

> - if successful, it can be used like a typical OpenHASP object

> Every time the user touches an active element on the screen, OpenHASP publishes internal events you can listen and react to. For example if you press a button `p1b10`, OpenHASP publishes an event `{"hasp":{"p1b10":{"event":"up"}}` when the button is released. You can easily create a rule to react to this event.

I do appreciate the shout-out to the openHASP project, but I think the tasmota implementation should be called something different than *OpenHASP*...