### PR TITLE
Update example for Wifi watchdog to working state

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -1759,35 +1759,33 @@ Notice we use `Rule` which edits `Rule1` rule set. They can be used interchangea
 
 ------------------------------------------------------------------------------
 
-### Watchdog for Wi-Fi router
+### Watchdog for Wi-Fi router or modem
 
-A Tasmota socket can ping a remote host (router itself or something else connected to the router)
-and power cycle the socket to reboot the router. In this example, ping interval of 3 minutes is used.
+A Tasmota WebQuery can fetch a URL from a remote host (router itself, something else connected to the router, or a site on the Internet)
+and power cycle the socket to reboot the router. In this example, an interval of 3 minutes is used.
 The simplest watchdog rule does not use variables:
 
 ```haskell
 Rule1
-  ON Time#Minute|3 DO Ping4 192.168.1.10 ENDON
-  ON Ping#192.168.1.10#Success==0 DO Backlog Power1 0; Delay 10; Power1 1; ENDON
+  ON Time#Minute|3 DO backlog WebQuery http://192.168.1.10 GET ENDON
+  ON WebQuery#Data$!Done DO backlog Power1 0; Delay 10; Power1 1 ENDON
 Rule1 1
 ```
 
-However, if the router becomes unreachable for a long time, the watchdog will keep cycling it every three minutes. 
-This could reduce the watchdog's relay lifetime to months, at most years. Safer option would be to use an 
-**exponential backoff** algorithm. `Var1` contains the current ping interval in minutes, which is trippled
-after each failed ping, but limited to 1439 minutes (1 day).
+However, if the endpoint becomes unreachable for a long time, the watchdog will keep cycling it every three minutes. 
+This could reduce the watchdog's relay lifetime to months, at most years. A safer option would be to use an 
+**exponential backoff** algorithm. `Var1` contains the current interval in minutes, which is tripled
+after each failed query, but limited to 1439 minutes (1 day).
 
 ```haskell
 Rule1
   ON system#boot do Var1 3 ENDON
   ON Var1#State>1439 DO Var1 1439 ENDON
-  
-  ON Time#Minute|%var1% DO Ping4 192.168.1.10 ENDON
-  ON Ping#192.168.1.10#Success==0 DO backlog Mult1 3; Power1 0; Delay 10; Power1 1 ENDON
-  ON Ping#192.168.1.10#Success>0 DO Var1 3 ENDON
-```
 
-!!! note "This requires `#define USE_PING` and Tasmota version 8.2.0.3 or newer"
+  ON Time#Minute|%var1% DO backlog WebQuery http:/192.168.1.10/ GET ENDON
+  ON WebQuery#Data$!Done DO backlog Mult1 3; Power1 0; Delay 10; Power1 1 ENDON
+  ON WebQuery#Data=Done DO Var1 3 ENDON
+```
 
 -------------------------------------------------------------------------------
 ### Simple Thermostat Example


### PR DESCRIPTION
The current example for the Wifi Watchdog has two problems: one, it requires Ping which isn't included by default; and two, it doesn't actually work.  The `Ping4` command needs to be wrapped in a backlog in order for the ruleset to work properly.  However, we have something more flexible than Ping - WebQuery.  It's also included in Tasmota by default.  This documentation change updates the example to use WebQuery in a way that actually works.