### PR TITLE
Add "EMH eHZ Generation K" to Smart-Meter-Interface.md

### DIFF
--- a/docs/Smart-Meter-Interface.md
+++ b/docs/Smart-Meter-Interface.md
@@ -426,7 +426,24 @@ The Tasmota SML script:
 ```
 
 ------------------------------------------------------------------------------
-	
+
+### EMH eHZ Generation K (SML)
+
+```
+>D
+>B
+ 
+=>sensor53 r
+>M 1
++1,3,s,0,9600,
+1,77070100010800ff@1000,Gesamtverbrauch,KWh,Total_in,2
+1,77070100020800ff@1000,Gesamteinspeisung,KWh,Total_out,2
+1,77070100100700ff@1,Verbrauch,W,Power_curr,0
+#
+```
+
+------------------------------------------------------------------------------
+		
 ### EMH mMe4.0 (SML)
 
 ```


### PR DESCRIPTION
added script for "EMH eHZ Generation K" (eHZ-KW8E2A5L0EQ2P) smartmeter used by the municipal utilities in my area
manual: https://emh-metering.com/wp-content/uploads/2020/08/eHZ-K-BIA-D-1-20.pdf