### PR TITLE
SetOption103 to enable MQTT TLS

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -51,6 +51,7 @@ To use it you must [compile your build](Compile-your-build) do the follow change
 ```C
 #ifndef USE_MQTT_TLS 
 #define USE_MQTT_TLS                             // Use TLS for MQTT connection (+34.5k code, +7.0k mem and +4.8k additional during connection handshake)
+#define MQTT_TLS_ENABLED       true              // [SetOption103] Enable TLS mode (requires TLS version)
 //  #define USE_MQTT_TLS_CA_CERT                   // Force full CA validation instead of fingerprints, slower, but simpler to use.  (+2.2k code, +1.9k mem during connection handshake)
                                                    // This includes the LetsEncrypt CA in tasmota_ca.ino for verifying server certificates
 //  #define USE_MQTT_TLS_FORCE_EC_CIPHER           // Force Elliptic Curve cipher (higher security) required by some servers (automatically enabled with USE_MQTT_AWS_IOT) (+11.4k code, +0.4k mem)


### PR DESCRIPTION
https://github.com/arendst/Tasmota/pull/15572/commits/2730df65c2c5a948daca8df2b7ccc05f3615cb94 made it so MQTT TLS is no longer automatically enabled when using port 8883.