### PR TITLE
Update PN532.md

### DIFF
--- a/docs/PN532.md
+++ b/docs/PN532.md
@@ -30,7 +30,7 @@ As mentioned earlier the PN532 breakout boards usually have pins broken out for 
 
 For this reason breakout boards have either micro dip switches as shown in the image below, or they have pads on the PC board which you need to bridge out with solder to select which mode the PN532 will operate in.
 
-![HSU Dipswitch Setting](https://raw.githubusercontent.com/andrethomas/images/master/pn532/pn532_nfc_hsu_config.PNG)
+![pn532_nfc_hsu_config](https://user-images.githubusercontent.com/62309445/188082792-8c57230f-fa53-4d08-8d33-fbacd5316144.png)
 
 After selecting the correct protocol mode and connecting the HSU TX/RX pins of the PN532 to the pins you configured on your ESP8266 board you can power it up and the PN532 should be detected automatically.
 


### PR DESCRIPTION
added arrows to explain configuration of DIP Switch position for HSU mode. Switches must be to the left as in the attached picture. 
I tried this tutorial and it worked with a device marked Elechouse.
See my comment on issue #4941