### PR TITLE
Use latest 8.0.6 esp-web-tools

### DIFF
--- a/docs/extra_javascript/web_flasher.js
+++ b/docs/extra_javascript/web_flasher.js
@@ -1,5 +1,5 @@
 ewt_s=document.createElement('script');ewt_s.type='module';
-ewt_s.src="https://unpkg.com/esp-web-tools@8.0.1/dist/web/install-button.js?module";
+ewt_s.src="https://unpkg.com/esp-web-tools@8.0.6/dist/web/install-button.js?module";
 document.body.append(ewt_s);
 
 ewt_b=document.createElement("esp-web-install-button");ewt_b.manifest="https://tasmota.github.io/install/manifest/release.tasmota.manifest.json";


### PR DESCRIPTION
since it has fixes. We use this version in repo Install too. Changelog https://github.com/esphome/esp-web-tools/releases
We do not want 9.x since it uses espressif.js as flasher which has bugs!