### PR TITLE
Update DS18x20.md

### DIFF
--- a/docs/DS18x20.md
+++ b/docs/DS18x20.md
@@ -81,12 +81,14 @@ Pinout when looking at the flat side of the TO-92 package sensor: GND, Signal, V
 
 ![RJ11](https://user-images.githubusercontent.com/11044339/187024676-1d29abcd-e19e-410f-95da-830b5c1fc7e4.png)
 
-|4P4C RJ11 pin | ESP | DS18b20 |
+|4P4C RJ10 pin | ESP | DS18b20 |
 |---|---|---|
 |1 (Yellow on image) |3V3 GPIO27 providing 3V3 | Red on wired sensor |
 |2 (Green on image) |GPIO25 data | Yellow or White on wired sensor |
 |3 (Red on image) |NC | |
 |4 (Black on image) |GND | Black on wired sensor |
+
+You do not need to add a pull-up resistor (The THR316D/THR320D has it built in.)
 
 ## ESP-01 Wiring Notes
 


### PR DESCRIPTION
Clarification to ## THR316D/THR320D Wiring Notes following implementing on THR316D

The plug is rj10 4p4c , not rj11.
Note added that no pullup resistor needed as included in hardware already.