### PR TITLE
Added information to AHT2x.md

### DIFF
--- a/docs/AHT2x.md
+++ b/docs/AHT2x.md
@@ -19,6 +19,8 @@
 |SDA   | GPIOx
 |SCL   | GPIOy
 
+!!! tip "AHT25 breakout boards require external pull-up resistors on the I2C bus (for example: 4.7kΩ)"
+
 
 ### Tasmota Settings 
 In the **_Configuration -> Configure Module_** page assign:


### PR DESCRIPTION
Add tip for adding external pull-up resistors for AHT25 breakout boards as mentioned in the datasheet.

From the datasheet, page 8:
> To avoid signal conflicts, the microprocessor (MCU) must only drive SDA and SCL at lowlevel.
An external pull-up resistor (for example: 4.7kΩ) is required to pull the signal to a highlevel.

![AHT22_1](https://user-images.githubusercontent.com/56406552/197359787-53329a8d-7325-4ae8-84f2-99d79ce9cd61.png)