### PR TITLE
Fix link from "Securing your IoT from hacking" to "Wi-Fi commands"

### DIFF
--- a/docs/Securing-your-IoT-from-hacking.md
+++ b/docs/Securing-your-IoT-from-hacking.md
@@ -138,7 +138,7 @@ How to generate the certificates in mosquitto please look at:
 
 Type WifiConfig into the tasmota console. If this parameter is set to 2, you might want to change it after completing the setup of your device since in case your Wifi SSID is not available (i.e. access point dies or WLAN jammer is used as in [Scanario 5](#scenario-5)), the WiFiManager will jump into action and make your tasmota devices available using an unsecured access point.
    
-   Some less risky options would be: 0/4/5. Currently the [default WiFiConfig value](https://github.com/arendst/Tasmota/issues/4400) is [(WIFI_RETRY)](https://github.com/arendst/Tasmota/blob/development/tasmota/my_user_config.h#L79) which means that device retries other AP without rebooting.  (For details, see [Wi-Fi commands](Commands#wi-fi)).
+   Some less risky options would be: 0/4/5. Currently the [default WiFiConfig value](https://github.com/arendst/Tasmota/issues/4400) is [(WIFI_RETRY)](https://github.com/arendst/Tasmota/blob/development/tasmota/my_user_config.h#L79) which means that device retries other AP without rebooting.  (For details, see [Wi-Fi commands](Commands.md#wi-fi)).
 
 ## Home Assistant OS MQTT Add-On
 If you are using Home Assistant OS [MQTT add-on](https://github.com/home-assistant/addons/tree/master/mosquitto) with [Tasmota integration](https://www.home-assistant.io/integrations/tasmota/) the devices will need write access to the `tasmota/discovery/#` topic.


### PR DESCRIPTION
Somehow links to other pages with anchors are broken:  ` [Wi-Fi commands](Commands#wi-fi)` builds this broken link: https://tasmota.github.io/docs/Securing-your-IoT-from-hacking/Commands#wi-fi

with the extra `.md` it somehow works (found via 59666ae309ada1af2eb88a34d5c80e4c56541c80, fixing #1057)

Links without anchors do work (such as `[TLS](TLS)`). I have not checked other instances of this issue, but they may exist...