### PR TITLE
Update ESP32.md to include SetOption146 and Warning to not use it 

### DIFF
--- a/docs/ESP32.md
+++ b/docs/ESP32.md
@@ -55,17 +55,14 @@ To use it you need to have `#define USE_AUTOCONF`.
 
 ### CPU Temperature Sensor
 
-Tasmota will create an internal temperature sensor and display the values in the webUI and MQTT.
+Tasmota will create an internal temperature sensor and display the values in the webUI and MQTT. The accuracy of this sensor varies a lot depending on the ESP32 chip involved and should not be taken as a reliable metric.
 
-Enable display of ESP32 internal temperature by command [`SetOption146 1`](Commands.md#setoption146) 
+Enable display of ESP32 internal temperature with [`SetOption146 1`](Commands.md#setoption146) 
 
 ```json
 {"Time":"2021-01-01T00:00:00","ESP32":{"Temperature":41.7},"TempUnit":"C"}
 ```
 You can deactivate sensor by using command [`SetSensor127 0`](Commands.md#setsensor127)
-
-!!! warning
-     It's much recommend to not use this feature because it's misleading and often it's a value without a clear relationship to reality..
 
 ### DAC
 

--- a/docs/ESP32.md
+++ b/docs/ESP32.md
@@ -57,11 +57,15 @@ To use it you need to have `#define USE_AUTOCONF`.
 
 Tasmota will create an internal temperature sensor and display the values in the webUI and MQTT.
 
+Enable display of ESP32 internal temperature by command [`SetOption146 1`](Commands.md#setoption146) 
+
 ```json
 {"Time":"2021-01-01T00:00:00","ESP32":{"Temperature":41.7},"TempUnit":"C"}
 ```
+You can deactivate sensor by using command [`SetSensor127 0`](Commands.md#setsensor127)
 
-You can activate it using command [`SetOption146 1`](Commands.md#setoption146)
+!!! warning
+     It's much recommend to not use this feature because it's misleading and often it's a value without a clear relationship to reality..
 
 ### DAC
 

--- a/docs/ESP32.md
+++ b/docs/ESP32.md
@@ -61,7 +61,7 @@ Tasmota will create an internal temperature sensor and display the values in the
 {"Time":"2021-01-01T00:00:00","ESP32":{"Temperature":41.7},"TempUnit":"C"}
 ```
 
-You can deactivate it using command [`SetSensor127 0`](Commands.md#setsensor127)
+You can activate it using command [`SetOption146 1`](Commands.md#setoption146)
 
 ### DAC
 


### PR DESCRIPTION
After a new release CPU temp disappear and at first I was searching in docs. Later I found out about change in Changelog, so I think it should be also here.

I don't know what about, "SetSensor127 0", so I replaced it for new command