### PR TITLE
Update DS18x20.md

### DIFF
--- a/docs/DS18x20.md
+++ b/docs/DS18x20.md
@@ -142,10 +142,10 @@ Single sensor attached:
 ```
 Multiple sensors attached:
 ```
-  ON DS1820_1#Temperature DO <command> ENDON
-  ON DS1820_2#Temperature DO <command> ENDON
-  ON DS1820_3#Temperature DO <command> ENDON
-  ON DS1820_..#Temperature DO <command> ENDON
+  ON DS1820-1#Temperature DO <command> ENDON
+  ON DS1820-2#Temperature DO <command> ENDON
+  ON DS1820-3#Temperature DO <command> ENDON
+  ON DS1820-..#Temperature DO <command> ENDON
 ```
 Example:
 ```


### PR DESCRIPTION
Naming for multiple sensors in Rule's trigger uses defis - not the underscore _.