### PR TITLE
Update Bluetooth_ESP32.md

### DIFF
--- a/docs/Bluetooth_ESP32.md
+++ b/docs/Bluetooth_ESP32.md
@@ -308,6 +308,16 @@ Backlog Rule1 ON System#Boot DO BLEAlias A4C1386A1E24=fred A4C1387FC1E1=james en
 
 #### Check the interval between BLE tele messages
 
+!!! note "about TRVPeriod and RTC"
+
+    In order of TRVPeriod to work and get the valves polled at regular intervales, you need to have the time and date of the tasmota device correctly configured, let it be using an RTC (real time clock) device connected to your tasmota or using NTP (Network Time Protocol).
+    To configues by default some known NTP servers, so usually the device would have its time automaticlly configured.
+    But if your device is connected to a local network isolated from internet, it won't get access to the configured NTP servers.
+    So you need to configure an NTP server in a device that is always running and connected to the same network as the TASMOTA device.
+    Good candidates for that are your router (if it has the option to activate an NTP server) or the device your are using for home automation (if you are using one).
+    Even if you have configured your TASMOTA device as a DHCP client in order to get the IP at boot, and your DHCP server is configured to set the NTP server to clients, TASMOTA devices do not admit that option, so you have to set the locall NTP server using `NTPserver` 
+
+
 `BLEPeriod`
 
 Set it to 40s: `BLEPeriod 40`


### PR DESCRIPTION
TRVPeriod won't work if time is not correctly stablished in the device. NTP won't work at its default configuration if the device is connected to an isolated LAN. It would worth to mention under the TRVPeriod comments.