### PR TITLE
Update DS18x20.md

### DIFF
--- a/docs/DS18x20.md
+++ b/docs/DS18x20.md
@@ -38,7 +38,7 @@ Shelly dual pin mode is supported by an additional pin assignment:
 - GPIOy to `DS18x20-o`   
 
 ### Commands
-[`SetOption74`](Commands.md#setoption74) may be used to enable/disable internal pullup when using a ***single*** DS18x20 sensor (for multiple sensors, you have to use an external pullup resistor).
+[`SetOption74`](Commands.md#setoption74) may be used to enable/disable internal pullup when using a ***single*** DS18x20 sensor (for multiple sensors, you have to use an external pullup resistor). Note: Experience has shown that the 4k7 is necessary even for a single DS18x20 sensor.  
 
 [`SetOption126`](Commands.md#setoption126) Enable arithmetic mean over teleperiod for JSON temperature for DS18x20 sensors.
 


### PR DESCRIPTION
Add the comment - "Note: Experience has shown that the 4k7 is necessary even for a single DS18x20 sensor".  

If the 4k7 is added then this command is not required so maybe a better change would be to remove the reference to the command and to add a note making the 4k7 mandatory.