### PR TITLE
fix links to images so MkDocs shows them

### DIFF
--- a/docs/devices/Smart-Light-Switch--SS118-01K1.md
+++ b/docs/devices/Smart-Light-Switch--SS118-01K1.md
@@ -6,16 +6,16 @@ Generic Smart Light Switch from Amazon
 [ESP8266-S1 Model](https://amzn.to/2lTz1e4) - ***August 2019***  
 
 ### Product 
-![Package](https://github.com/willngton/Smarth_Plug_LA_WF3/blob/master/Switch_SS118_01.png)
-![Back](https://github.com/willngton/Smarth_Plug_LA_WF3/blob/master/Switch_SS118_02.png)
-![Internal](https://github.com/willngton/Smarth_Plug_LA_WF3/blob/master/Switch_SS118_03.png)
-![Internal](https://github.com/willngton/Smarth_Plug_LA_WF3/blob/master/Switch_SS118_04.png)
+![Package](https://raw.githubusercontent.com/willngton/Smarth_Plug_LA_WF3/master/Switch_SS118_01.png)
+![Back](https://raw.githubusercontent.com/willngton/Smarth_Plug_LA_WF3/master/Switch_SS118_02.png)
+![Internal](https://raw.githubusercontent.com/willngton/Smarth_Plug_LA_WF3/master/Switch_SS118_03.png)
+![Internal](https://raw.githubusercontent.com/willngton/Smarth_Plug_LA_WF3/master/Switch_SS118_04.png)
 
 ### Pins
-![Pins](https://github.com/willngton/Smarth_Plug_LA_WF3/blob/master/Switch_SS118_05.png)
+![Pins](https://raw.githubusercontent.com/willngton/Smarth_Plug_LA_WF3/master/Switch_SS118_05.png)
 
 ### Module Configuration
-![TASMOTA Configuration](https://github.com/willngton/Smarth_Plug_LA_WF3/blob/master/Switch_SS118_06.png)
+![TASMOTA Configuration](https://raw.githubusercontent.com/willngton/Smarth_Plug_LA_WF3/master/Switch_SS118_06.png)
 
 ***
 ***New Version - August 2019***


### PR DESCRIPTION
Images weren't showing up on the [MkDocs Page](https://tasmota.github.io/docs/devices/Smart-Light-Switch--SS118-01K1) because the images were linked to full github pages. I changed them to the raw images.