### PR TITLE
Changed 'and' to 'or' for sunset/sunrise compare

### DIFF
--- a/docs/Scripting-Language.md
+++ b/docs/Scripting-Language.md
@@ -1321,7 +1321,7 @@ remark: the Flash illumination LED is connected to GPIO4
     print %upsecs% %uptime% %time% %sunrise% %sunset% %tstamp%
 
     if time>sunset
-    and time<sunrise
+    or time<sunrise
     then
     ; night time
     if pwr[1]==0


### PR DESCRIPTION
This wrong example took me some time troubleshooting.... The if statement will never evaluate to `true` at nighttime by using `and`. I think `or` should be used instead for the nighttime example. 

Explanation: when i run `print Time is %time%. Sunrise is at %sunrise%, sunset is at %sunset%.` in the console of my Tasmota device in timezone Europe/Amsterdam and with the correct local time i get: 
`Time is 1252.00. Sunrise is at 402.00, sunset is at 1131.00.`

The condition ` if time>sunset and time<sunrise` will never be true., but using `or` it will.