### PR TITLE
Add description of configuring a switch for autodiscovery.

### DIFF
--- a/docs/PIR-Motion-Sensors.md
+++ b/docs/PIR-Motion-Sensors.md
@@ -2,7 +2,7 @@ PIR motion sensors, albeit called sensors, are configured as switches in Tasmota
 
 Most PIR's are single wire and they require connecting to VCC, GND and one GPIO. In this guide we will use `GPIO13` as the pin that the PIR output is connected to. See [PIN Restrictions](Peripherals.md#restrictions) on which pins not to use
 
-### Tasmota Settings
+### Tasmota Settings for Rules
 In **_Configuration -> Configure Module_** menu change `GPIO13` to `Switch1`.
 ![Step 1](_media/GPIO13-switch.png)
 
@@ -25,6 +25,25 @@ Before using rules configure any GPIO that doesn't have anything connected to it
 This creates a dummy relay which is triggered by the PIR so you can see the changes in the web UI. This method is not recommended for daily use and should only be used for testing.
 
 A more [advanced example](Rules#auto-off-motion-sense-switch) of rules with PIRs.
+
+### Tasmota Settings for HomeAssistant Autodiscovery
+
+Alternatively, a PIR motion sensor can be configured as a switch with its state reported for autodiscovery by HomeAssistant.
+
+[Detach switches from relays](https://tasmota.github.io/docs/Commands/#setoption114) and send MQTT messages instead:
+
+```console
+SetOption114 1
+```
+
+To have switches discovered SwitchTopic must be set to a custom name. And the [switch mode](https://tasmota.github.io/docs/Buttons-and-Switches/#switchmode) should be set to follow.
+
+```console
+SwitchTopic1 pir
+SwitchMode1 1
+```
+
+After this, the PIR sensor "switch" will be autodiscovered in Home Assistant as a sensor.
 
 ## AM312 
 


### PR DESCRIPTION
This method works for me quickly/easily. The default instructions only make something show up in the UI if I use the relay, which is not recommended. And there are much more complicated workarounds described, for example at https://blakadder.com/pir-in-tasmota-integration/ , and a number of threads one can find with people trying to figure out how to do this. So I think it would really help to have this method described in the main PIR docs.