### PR TITLE
Fixed syntax of unordered lists in TasmoAdmin chapter

### DIFF
--- a/docs/TasmoAdmin.md
+++ b/docs/TasmoAdmin.md
@@ -1,12 +1,13 @@
-TasmoAdmin is an administrative Website for Devices flashed with [Tasmota](https://github.com/arendst/Tasmota).   
+TasmoAdmin is an administrative Website for Devices flashed with [Tasmota](https://github.com/arendst/Tasmota).  
 You can find it here: [TasmoAdmin GitHub](https://github.com/TasmoAdmin/TasmoAdmin).
 It supports running on Windows, Linux and as Docker container.
 
 ## Features
+
 * Login protected
 * Multi Update Process
-  * Select devices to update
-  * Automatic Modus downloads latest firmware bin from Tasmota GitHub
+    * Select devices to update
+    * Automatic Modus downloads latest firmware bin from Tasmota GitHub
 * Show device information
 * Mobile Responsive (Bootstrap4)
 * Config devices
@@ -27,36 +28,55 @@ This is a Linux Alpine  based image with Nginx and PHP7 installed. It supports m
 This is the recommended way to get up and running.
 
 ### Linux
+
 Running TasmoAdmin on a Linux/Unix hosts requires the following:
+
 * A Webserver
-  * apache2 recommended
-  * php7 recommended (works with php5 too)
-  * php-curl php-zip Modules installed
+    * apache2 recommended
+    * php7 recommended (works with php5 too)
+    * php-curl php-zip Modules installed
 
 You need to install a web server with php-zip and php-curl modules installed. Also mod_rewrite must be enabled. I suggest to look in the [Guide for Ubuntu Server 16.04](https://github.com/TasmoAdmin/TasmoAdmin/wiki/Guide-for-Ubuntu-Server-16.04) and try to adjust it to your server OS.
 
 ## Example Images
+
 #### Login Page
+
 ![Login](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/1.png)
+
 #### Start Page
+
 ![Startpage](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/2.png)
+
 #### Devices Page
+
 ![Devices](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/3.png)
+
 #### Devices Add/Edit Page
+
 ![Device Add/Edit](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/3_1.png)
+
 #### Config General Page
+
 ![Device Config_GENERAL](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/4.png)
+
 #### Config Network Page
+
 ![Device Config_Network](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/4_1.png)
+
 #### Update Devices Page
+
 ![Device Update 1](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/5.png)
 ![Device Update 2](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/5_1.png)
 ![Device Update 3](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/5_2.png)
+
 #### Settings Page
+
 ![Settings](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/6.png)
 ![Settings](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/7.png)
 
 #### Mobile
+
 ![Navi_M](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/m1.png)
 ![Startpage_M](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/m2.png)
 ![Devices_M](https://raw.githubusercontent.com/reloxx13/reloxx13.github.io/master/media/tasmoadmin/readme/m3.png)


### PR DESCRIPTION
I'm pretty new to Tasmota. Reading the docs I noticed that the syntax of the unordered lists does not seem to match the guidelines given in the [Markdown guide](https://www.markdownguide.org/basic-syntax/#unordered-lists). Due to the missing spaces the indented items were not rendered correctly.