### PR TITLE
Update Smart-Meter-Interface.md

### DIFF
--- a/docs/Smart-Meter-Interface.md
+++ b/docs/Smart-Meter-Interface.md
@@ -2200,6 +2200,28 @@ Switching to different baud rates requires changing the ack sequence 06303x300D0
     1,1-0:16.7.0*255(@1,Verbrauch aktuell,W,power,20
     #
     ```
+### Logarex LK13BE803039
+
+The Logarex LK13BE803039 does publish the data automatically. Do not poll this can lead to missreadings
+	
+??? summary "View script"
+    ```
+    >D
+    >B
+    =>sensor53 r
+    >M 1
+    +1,3,o,0,9600,LK13BE
+
+    1,1-0:1.8.0*255(@1,Gesamtverbrauch,KWh,total,4
+    1,1-0:1.8.0*96(@1,Verbrauch 1 Tag,KWh,total_1d,4
+    1,1-0:1.8.0*97(@1,Verbrauch 7 Tage,KWh,total_7d,4
+    1,1-0:1.8.0*98(@1,Verbrauch 30 Tage,KWh,total_30d,4
+    1,1-0:1.8.0*99(@1,Verbrauch 365 Tage,KWh,total_365d,4
+    1,1-0:16.7.0*255(@1,Verbrauch aktuell,W,current,20
+    1,1-0:2.8.0*255(@1,Gesamteinspeisung,KWh,total_out,4
+    #
+
+    ```
 
 ### Logarex LK13BE803319 (OBIS)
 setupline for the  HichiIR WiFi module (GPIO1: send, GPIO3: receive)


### PR DESCRIPTION
#1240 LOGAREX LK13BE803039 does send the data by itself and it causes wrong readings when tx is configured.