### PR TITLE
added the matrix group link as a privacy preserving alternative

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -354,4 +354,4 @@ Arduino Core (open source) are the core libraries for ESP8266/ESP8285 chips to m
 You can see the Arduino Core Version and the Espressif SDK Version on the Tasmota WebUI under the Information Menu entry.
 
 ## I Cannot Find An Answer Here!
-Check the [Troubleshooting](Troubleshooting) section or join [Discord](https://discord.gg/Ks2Kzd4), [Telegram](https://t.me/tasmota), [Reddit](https://www.reddit.com/r/tasmota/) or [Google Groups](https://groups.google.com/d/forum/sonoffusers) for assistance from other Tasmota users.  
+Check the [Troubleshooting](Troubleshooting) section or join [Discord](https://discord.gg/Ks2Kzd4), [Matrix](https://matrix.to/#/%23tasmota:matrix.org), [Telegram](https://t.me/tasmota), [Reddit](https://www.reddit.com/r/tasmota/) or [Google Groups](https://groups.google.com/d/forum/sonoffusers) for assistance from other Tasmota users.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ For feedback, questions, live troubleshooting or just general chat
 <a href="https://discord.gg/Ks2Kzd4"><img src="https://discordapp.com/api/guilds/479389167382691863/widget.png?style=banner3"></a>
 
 - [Telegram](https://t.me/tasmota)
+- [Matrix](https://matrix.to/#/%23tasmota:matrix.org)
 - [Reddit](https://www.reddit.com/r/tasmota/) 
 - [Google Groups](https://groups.google.com/d/forum/sonoffusers)
 


### PR DESCRIPTION
The telegram group is bridged with a matrix room but the existence of said room is not yet documented anywhere. This PR adds it so privacy minded people (which i assume quite a few tasmota users are) can directly join the matrix room instead of needing to join the telegram room in order to find out matrix exists and ask for the room id