### PR TITLE
Add sonoff s31 docs for prom units mismatch

### DIFF
--- a/docs/devices/Sonoff-S31.md
+++ b/docs/devices/Sonoff-S31.md
@@ -26,3 +26,6 @@ Tinkerman's review of [Sonoff S31](http://tinkerman.cat/sonoff-s31-now-serious/)
 
 ### Video tutorial by Robert Cowan
 [![](https://youtu.be/IvfiLcHMekQ "")
+
+### Prometheus power metrics units
+When enabled, the prometheus exporter will report `energy_power_kilowatts_daily` and `energy_power_kilowatts_total` metrics. While the naming convention implies that the metrics' values are measured in kilowatts, they are in fact measurements of kilowatt _hours_.


### PR DESCRIPTION
## Summary
As mentioned in [this issue](https://github.com/arendst/Tasmota/issues/19538), on the Sonoff S31, the prometheus metrics `energy_power_kilowatts_daily` and `energy_power_kilowatts_total` report values whose units are kilowatt _hours_ rather than kilowatts, as implied by the naming convention.

This change adds an update to the Sonoff S31 device documentation to point this out.

### Notes
Ideally, we'd update the metric names, but those metrics are shared across quite a few devices so implementing the name change would be quite a bit of effort for a pedantic fix. In the mean time, folks running into this issue can work around it with [metric relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs).