### PR TITLE
Fix Sonoff S31 Robert Cowan tutorial thumbnail

### DIFF
--- a/docs/devices/Sonoff-S31.md
+++ b/docs/devices/Sonoff-S31.md
@@ -25,4 +25,4 @@ Tinkerman's review of [Sonoff S31](http://tinkerman.cat/sonoff-s31-now-serious/)
 [![](http://img.youtube.com/vi/kKtLKjI4wA0/0.jpg)](http://www.youtube.com/watch?v=kKtLKjI4wA0 "")
 
 ### Video tutorial by Robert Cowan
-[![](https://youtu.be/IvfiLcHMekQ "")
+[![](http://img.youtube.com/vi/IvfiLcHMekQ/0.jpg)](https://youtu.be/IvfiLcHMekQ "")


### PR DESCRIPTION
## Summary
In the Sonoff S31 docs, the Robert Cowan tutorial link is formatted as an image link, but doesn't have an image to load. This change updates the docs to display the linked video's thumbnail.