### PR TITLE
Add note for ADC CT Power users

### DIFF
--- a/docs/Power-Monitoring-Calibration.md
+++ b/docs/Power-Monitoring-Calibration.md
@@ -5,6 +5,9 @@
 - A **known** wattage load with a **power factor as close to 1** as possible (e.g., a resistive load) for best results  
 
 !!! note
+    For CT Power using ADC, see the [adcparam]([url](https://tasmota.github.io/docs/ADC/#commands:~:text=Parameters-,AdcParam%3Cx%3E,-ADC%20analog%20input)) page.
+
+!!! note
     A resistive load device is any device which draws a constant amount of power. For example, an incandescent or halogen light bulb         (best choice since their power draw is declared on them). An electric kettle, heater, or blow dryer are also options but you will       also need a power meter since the power draw *could* vary.  
 
 !!! danger

--- a/docs/Power-Monitoring-Calibration.md
+++ b/docs/Power-Monitoring-Calibration.md
@@ -5,7 +5,7 @@
 - A **known** wattage load with a **power factor as close to 1** as possible (e.g., a resistive load) for best results  
 
 !!! note
-    For CT Power using ADC, see the [adcparam]([url](https://tasmota.github.io/docs/ADC/#commands:~:text=Parameters-,AdcParam%3Cx%3E,-ADC%20analog%20input)) page.
+    Does not apply to CT Power modules using ADC. For those, see [`adcparam`]([url](https://tasmota.github.io/docs/ADC/#commands:~:text=Parameters-,AdcParam%3Cx%3E,-ADC%20analog%20input))
 
 !!! note
     A resistive load device is any device which draws a constant amount of power. For example, an incandescent or halogen light bulb         (best choice since their power draw is declared on them). An electric kettle, heater, or blow dryer are also options but you will       also need a power meter since the power draw *could* vary.  


### PR DESCRIPTION
Users looking to calibrate their clamp ammeter devices (CT Power module hooked to ADC pin) can't use the commands on the page titled "Power-Monitoring-Calibration" because the PowerSet/VoltageSet/etc. commands don't apply to ADC-based measurements. Instead, those users need to calibrate using the `adcparam` command.

This PR adds a note pointing them in the right direction.

Hopefully this helps people to find what they want and avoid filing issues like these:
https://github.com/arendst/Tasmota/issues/8011
https://github.com/arendst/Tasmota/issues/7672