### PR TITLE
Fix typo in HDMI_CEC.md

### DIFF
--- a/docs/HDMI_CEC.md
+++ b/docs/HDMI_CEC.md
@@ -102,7 +102,7 @@ In the above, Tasmota sends command `8F` (Give Device Power Status) to query the
 
 Command: `HdmiSend 04`
 
-### Turning the TV on
+### Turning the TV off
 
 Command: `HdmiSend 36`
 


### PR DESCRIPTION
It's just a small typo, but it could lead to some mistakes on the future or to some users right now. [More info](https://support.justaddpower.com/kb/article/68-cec-over-ip-control/#:~:text=on%20most%20displays-,Power%20Off,-E0%2036)