### PR TITLE
Add Auto discovery

### DIFF
--- a/docs/Auto-Discovery.md
+++ b/docs/Auto-Discovery.md
@@ -1,0 +1,41 @@
+description: Device auto discovery
+
+# Auto discovery
+Tasmota auto discovery is meant to replace deprecated [Home Assistant discovery]([Home-Assistant.md](Home-Assistant.md#legacy-discovery-format)) (`SetOption19`) by a custom discovery format better suited for Tasmota.
+
+> Home Assistant's MQTT discovery protocol includes a lot of redundant information which increases Tasmota's code size, and has some crucial limitations e.g. RGBxx lights flickering when turning on from HA.
+> Also, Home Assistant's MQTT discovery protocol is not easy to add new features or make breaking changes to. (https://github.com/arendst/Tasmota/issues/9267)
+
+## Availability
+* Starting `v9.3.1.2` Tasmota ships with its format as an alternative to Home Assistant discovery.
+* Since `v11.1.0.2` Home Assistant discovery is considered deprecated.
+
+## Discovery message format
+Topic: `tasmota/discovery/49A3BC`
+
+Payload:
+```
+{
+  "ip":"192.168.15.10",                             // IP address
+  "dn":"Living Room",                               // Device name
+  "fn":["Ceiling Lamp", "Floor Lamp"],              // List of friendly names
+  "hn":"tasmota_49A3BC-0956",                       // Hostname
+  "id":"49A3BC",                                    // ChipID
+  "md":"Sonoff Dual",                               // Module
+  "of":"Offline",                                   // D_OFFLINE
+  "on":"Online",                                    // D_ONLINE
+  "st":["OFF","ON","TOGGLE","HOLD"],                // StateText[0..3]
+  "bd":"8.4.0.2",                                   // Tasmota SW build version
+  "t":"tasmota_49A3BC",                             // Topic
+  "ft":"%prefix%/%topic%/",                         // Fulltopic
+  "tp":["cmnd","stat","tele"],                      // [SUB_PREFIX, PUB_PREFIX, PUB_PREFIX2]
+  "li":[0,0,0,0,0,0,0,0],                           // Lights, 0: disabled, 1: Enabled
+  "rl":[0,0,0,0,0,0,0,0],                           // Relays, 0: disabled, 1: relay, 2.. future extension (fan, shutter?)
+  "sw":[0,0,0,0,0,0,0,0],                           // Switches, 0: disabled: 1: enabled
+  "bt":[0,0,0,0],                                   // Buttons, 0: disabled: 1: enabled
+  "so":{"13":0,"17":1,"30":0,"37":1,"68":0,"73":1}, // SetOption needed by HA to map Tasmota devices to HA entities and triggers
+  "lt_st":0,                                        // Light subtype
+  "se":[0],                                         // Sensors, 0: disabled, 0..xx index in kHAssJsonSensorTypes (??)
+  "ver":1                                           // Discovery protocol version, must be 1
+}
+```

--- a/docs/Auto-Discovery.md
+++ b/docs/Auto-Discovery.md
@@ -16,26 +16,24 @@ Topic: `tasmota/discovery/49A3BC`
 Payload:
 ```
 {
-  "ip":"192.168.15.10",                             // IP address
+  "btn":[0,0,0,0],                                  // Buttons, 0: disabled: 1: enabled
   "dn":"Living Room",                               // Device name
+  "ip":"192.168.15.10",                             // IP address
   "fn":["Ceiling Lamp", "Floor Lamp"],              // List of friendly names
-  "hn":"tasmota_49A3BC-0956",                       // Hostname
-  "id":"49A3BC",                                    // ChipID
-  "md":"Sonoff Dual",                               // Module
-  "of":"Offline",                                   // D_OFFLINE
-  "on":"Online",                                    // D_ONLINE
-  "st":["OFF","ON","TOGGLE","HOLD"],                // StateText[0..3]
-  "bd":"8.4.0.2",                                   // Tasmota SW build version
-  "t":"tasmota_49A3BC",                             // Topic
   "ft":"%prefix%/%topic%/",                         // Fulltopic
-  "tp":["cmnd","stat","tele"],                      // [SUB_PREFIX, PUB_PREFIX, PUB_PREFIX2]
-  "li":[0,0,0,0,0,0,0,0],                           // Lights, 0: disabled, 1: Enabled
+  "hn":"tasmota_49A3BC-0956",                       // Hostname
+  "mac":"49A3BC873A78",                             // MAC address
+  "md":"Sonoff Dual",                               // Module
+  "ofln":"Offline",                                 // D_OFFLINE
+  "onln":"Online",                                  // D_ONLINE
   "rl":[0,0,0,0,0,0,0,0],                           // Relays, 0: disabled, 1: relay, 2.. future extension (fan, shutter?)
-  "sw":[0,0,0,0,0,0,0,0],                           // Switches, 0: disabled: 1: enabled
-  "bt":[0,0,0,0],                                   // Buttons, 0: disabled: 1: enabled
   "so":{"13":0,"17":1,"30":0,"37":1,"68":0,"73":1}, // SetOption needed by HA to map Tasmota devices to HA entities and triggers
+  "state":["OFF","ON","TOGGLE","HOLD"],             // StateText[0..3]
+  "sw":"13.3.0"                                     // Tasmota SW build version
+  "swc":[0,0,0,0,0,0,0,0],                          // Switches, 0: disabled: 1: enabled
+  "t":"tasmota_49A3BC",                             // Topic
+  "tp":["cmnd","stat","tele"],                      // [SUB_PREFIX, PUB_PREFIX, PUB_PREFIX2]
   "lt_st":0,                                        // Light subtype
-  "se":[0],                                         // Sensors, 0: disabled, 0..xx index in kHAssJsonSensorTypes (??)
   "ver":1                                           // Discovery protocol version, must be 1
 }
 ```

--- a/docs/Home-Assistant.md
+++ b/docs/Home-Assistant.md
@@ -11,7 +11,7 @@ Tasmota communicates with Home Assistant using MQTT. Before going any further, m
 Home Assistant can add Tasmota devices using:
 
 1. Official Tasmota integration - **preferred** and automatic instant discovery of entities
-2. Deprecated legacy discovery format `SetOption19`
+2. Legacy Home Assistant discovery format **deprecated**
 3. Manual configuration by editing configuration.yaml - recommended for marginal use cases, e.g., TuyaMCU fan devices
 
 ## Tasmota Integration

--- a/docs/Home-Assistant.md
+++ b/docs/Home-Assistant.md
@@ -11,11 +11,16 @@ Tasmota communicates with Home Assistant using MQTT. Before going any further, m
 Home Assistant can add Tasmota devices using:
 
 1. Official Tasmota integration - **preferred** and automatic instant discovery of entities
-2. Manual configuration by editing configuration.yaml - recommended for marginal use cases, e.g., TuyaMCU fan devices
+2. Deprecated legacy discovery format `SetOption19`
+3. Manual configuration by editing configuration.yaml - recommended for marginal use cases, e.g., TuyaMCU fan devices
 
 ## Tasmota Integration
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=Tasmota)
+
+## Legacy discovery format
+
+!!! failure "`SetOption19` is deprecated in favor of [Tasmota discovery format](Auto-Discovery.md). The new format is also used by the Home Assistant integration."
 
 Once you configure the [Home Assistant](https://www.home-assistant.io/integrations/tasmota/) integration every new Tasmota device with `SetOption19 0` set will be discovered automatically. 
 


### PR DESCRIPTION
Adding MQTT auto discovery: #1315

Some keys were renamed/dropped from the initial proposal https://github.com/tasmota/docs/issues/1315:

```
{
  "bd":"8.4.0.2",                                   // Tasmota SW build version - now sw
  "bt":[0,0,0,0],                                   // Buttons, 0: disabled: 1: enabled - now btn
  "id":"49A3BC",                                    // ChipID
  "li":[0,0,0,0,0,0,0,0],                           // Lights, 0: disabled, 1: Enabled
  "of":"Offline",                                   // D_OFFLINE - now ofln
  "on":"Online",                                    // D_ONLINE - now onln
  "se":[0],                                         // Sensors, 0: disabled, 0..xx index in kHAssJsonSensorTypes (??)
  "st":["OFF","ON","TOGGLE","HOLD"],                // StateText[0..3] - now state
  "sw":[0,0,0,0,0,0,0,0],                           // Switches, 0: disabled: 1: enabled - now swc?
}
```

I also stumbled upon some keys that were not in the proposal but could not figure out what they are:

```
{
  "bat":0,                                         // battery?
  "dslp":0,
  "if":0,
  "lk":0,
  "ty":0,
  "sho":[],
  "sht":[]
  "swc":[-1,-1,-1,-1,-1,-1,-1,-1],                 // I suppose this was sw, but why -1?
  "swn":[null,null,null,null,null,null,null,null],
}