### PR TITLE
Getting-Started.md: Factory binaries to be used for ESP32 initial flashing

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -238,8 +238,10 @@ Choose an installation method:
     ```
     esptool.py write_flash -fm dout 0x0 tasmota.bin
     ```
-    or for ESP32
-    
+    or for ESP32:
+    !!! note
+        _Factory_ binaries are used for inital flashing this time
+        https://ota.tasmota.com/tasmota32/release/
     ```
     esptool.py write_flash 0x0 tasmota32.factory.bin
     ```


### PR DESCRIPTION
It's important to emphasize _Factory_ binaries are used for ESP32 initial flashing.
Otherwise it's easy to overlook and hard to debug then.