### PR TITLE
fix heading level in Codes-for-IR-Remotes.md

### DIFF
--- a/docs/Codes-for-IR-Remotes.md
+++ b/docs/Codes-for-IR-Remotes.md
@@ -7,7 +7,7 @@ Feel free to contribute this list.
 
 ## TV's
 
-## Samsung AA59 TV remote controller
+### Samsung AA59 TV remote controller
 
 **Example IRsend Command:**
 


### PR DESCRIPTION
The Samsung IR remote heading was incorrect and needed another #