### PR TITLE
Correct pin numbers for second serial port (they were swapped).

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -628,7 +628,7 @@ See also|[`SetOption8`](#setoption8) - change temperature display unit<br>[`SetO
 
 ### Serial Bridge
 
-Hardware Serial Bridge uses `GPIO1 (Tx)` and `GPIO3 (Rx)` or `GPIO13 (Tx)` and `GPIO15 (Rx)` pins of your device.
+Hardware Serial Bridge uses `GPIO1 (Tx)` and `GPIO3 (Rx)` or `GPIO15 (Tx)` and `GPIO13 (Rx)` pins of your device.
 Software Serial Bridge can use any other GPIO to be configured as components `Serial Tx` and `Serial Rx` (or `SerBr Tx` and `SerBr Rx`). If `Tx` and `Rx` components are not assigned in the Template or Module, `GPIO1` and `GPIO3` will be used. Note that changing serial logging ([`SerialLog`](#seriallog) 0) will disable the hardware Serial Bridge.
 
 Information received by Tasmota over the serial bridge is captured automatically. Before data will be received, a properly formatted [`SerialSend<x>` or `SSerialSend<x>`](#serialsend) command must be executed. This must be done any time the device restarts (e.g., via a `System#Boot` triggered rule). This command is required in order to set how the expected serial data will be formatted and interpreted (i.e., which <x> option). A `{"SSerialReceived":{"Data":"<string>"}}` message will be posted. You can use [a rule](Rules#control-relays-via-serial) to process the string which will be contained in `SSerialReceived#Data`.


### PR DESCRIPTION
The pin numbers for the second serial hardware port of ESP8266 were swapped in the description.

A description of the difference of Serial Tx/Serial Rx and SerBr Tx/SerBr Rx would be also good. I tested on a ESP 8266
Module type: Generic (18)
Serial Tx/Rx was working as expected on the second hardware port (console and MQTT), but SerBr did not work for me. What's the purpose of this option?