### PR TITLE
Reduce the number of rules in the "Solar heater control" example

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -2071,12 +2071,10 @@ mem3 25
 
 ```haskell
 rule1
-  ON DS18B20-1#temperature DO event t1=%value% ENDON
+  ON DS18B20-1#temperature DO Backlog0 var2 %value%; add2 1 ; var3 %value%; add3 2 ENDON
   ON DS18B20-2#temperature DO event t2=%value% ENDON
   ON event#t2>%mem3% DO var1 1 ENDON
   ON event#t2<=%mem3% DO var1 0 ENDON
-  ON event#t1 DO Backlog var2 %value%; add2 1 ENDON
-  ON event#t1 DO Backlog var3 %value%; add3 2 ENDON
   ON event#t2>%var3% DO Power1 %var1% ENDON
   ON event#t2<%var2% DO Power1 0 ENDON
 ```


### PR DESCRIPTION
With two sensors triggering events concurrently at high rate, I have observed the POWER being flipped back and forth regardless of the hysteresis. The problem is Backlog inserts 200 ms delay between commands. Which may be useful for some commands but in case of manipulating variables not necessary and apparently creates race conditions between
the `AddX` commands and `event#t2` comparisons (see the [discussion](https://github.com/arendst/Tasmota/discussions/20806)).
