### PR TITLE
Update SDS011.md

### DIFF
--- a/docs/SDS011.md
+++ b/docs/SDS011.md
@@ -35,8 +35,8 @@ See [manufacturer site](http://www.inovafitness.com/en/a/chanpinzhongxin/95.html
 
 ### Tasmota Settings
 In the **_Configuration -> Configure Module_** page assign:
-1. GPIO RX to `SDS0X1 Tx (101)`
-2. GPIO TX to `SDS0X1 Rx (70)`
+1. GPIO TX to `SDS0X1 Tx (101)`
+2. GPIO RX to `SDS0X1 Rx (70)`
 
 ![screenshot-2021-10-14_08-36-17](https://user-images.githubusercontent.com/174291/137264541-128ce4c2-c08e-46f2-9700-d4c30679870d.png)
 


### PR DESCRIPTION
Screenshot shows the right configuration (GPIO TX => SDS0X1 TX) but text was wrong.

It's not working with how it's written currently, `SDS0X1 TX` is also kinda misleading since it's pin RX on SDS0X1 and TX on ESP8266/32