### PR TITLE
Rules.md: Correct description of pressure cooker example

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -362,7 +362,7 @@ When the `<if-statement>` is preceded by other Tasmota commands you should use `
    `ON Power2#state=1 DO IF (Mem1==0) Var1 Var1+1; Mem1 1 ENDIF; Delay 10; Power1 on ENDON`
 
 !!! example
-     Rule used to control pressure cooker with a Sonoff S31. Once it is finished cooking, shut off the power immediately.  
+     Rule used to control pressure cooker with a Sonoff S31. Once it is finished cooking, shut off the power after 10 minutes.  
 ```haskell
 Rule1
  ON system#boot DO var1 0 ENDON


### PR DESCRIPTION
Rules.md: Correct description of pressure cooker example. Example said it would shut off power immediately, but the code would only shut it off if the pressure cooker remained off for 10 minutes.