### PR TITLE
fix #1449 , but has dependency on mkdocs 1.6

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,9 +9,10 @@ docs_dir: docs
 
 plugins:
   - search:
+      min_search_length: 2
       lang:
         - de
-        - en
+        - en       
   - alternate-link
   - minify:
       minify_html: true


### PR DESCRIPTION
the script command sections consist of only 2 characters (i.e. >D), hence with default search setting they will not be reported as hits. See https://www.mkdocs.org/user-guide/configuration/#min_search_length