### PR TITLE
Update Meter MT631 in Smart-Meter-Interface.md

### DIFF
--- a/docs/Smart-Meter-Interface.md
+++ b/docs/Smart-Meter-Interface.md
@@ -2205,8 +2205,7 @@ You need to ask your provider.
 
 ### Iskra MT 631 (SML)
 
-This meter needs a PIN to unlock the current power usage.
-You need to ask your provider. Total Delivered might be zero on some devices
+This meter requires a PIN to unlock the current power usage details. To obtain the PIN, you'll need to contact your utility provider. Once you have the PIN, deactivate it on the meter and enable the detailed information display to also get the "Current Consumption". Please note that the "Total Delivered" value may show as zero on some devices.
 
 ??? summary "View script"
     ```


### PR DESCRIPTION
You have to activate the detailed output in the meter to get the Current Consumption. This was previously not mentioned but is necessary.