### PR TITLE
Updated esptool docs

### DIFF
--- a/docs/Create-your-own-Firmware-Build-without-IDE.md
+++ b/docs/Create-your-own-Firmware-Build-without-IDE.md
@@ -246,7 +246,7 @@ If this GPIO0 is connected to GND when the module gets power, it starts in a fir
 Switch off the power of the board, this will be the reference 'steady state' of the system.
 
 ```
-(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py read_flash 0x00000 0x100000 fcmila_bulb_orig.bin
+(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py read-flash 0x00000 0x100000 fcmila_bulb_orig.bin
 esptool.py v2.6
 Found 1 serial ports
 Serial port /dev/cuaU0
@@ -280,11 +280,11 @@ If done, then **power the module off**, as this management mode is not restartab
 If it's not well, then you may try some queries:
 
 ```
-(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py -p /dev/ttyU0 chip_id
+(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py -p /dev/ttyU0 chip-id
 ...
 Chip ID: 0x00e02af2
 ...
-(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py -p /dev/ttyU0 flash_id
+(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py -p /dev/ttyU0 flash-id
 ...
 Manufacturer: c8
 Device: 4014
@@ -301,7 +301,7 @@ Until you can't get this step working, don't proceed to the next one, it won't w
 (With the usual button-pressed-power-on rain dance, and don't forget to power the module off afterwards.)
 
 ```
-(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py erase_flash
+(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py erase-flash
 ...
 Erasing flash (this may take a while)...
 Chip erase completed successfully in 1.6s
@@ -310,7 +310,7 @@ Chip erase completed successfully in 1.6s
 ## Install the firmware to your module
 
 ```
-(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py write_flash --flash_size 1MB --flash_mode dout 0x00000 firmware.bin
+(esptool) [tasmota_installer@lantash ~/esptool]$ esptool.py write-flash --flash-size 1MB --flash-mode dout 0x00000 firmware.bin
 Configuring flash size...
 Compressed 535424 bytes to 367679...
 Wrote 535424 bytes (367679 compressed) at 0x00000000 in 33.8 seconds (effective 126.6 kbit/s)...

--- a/docs/ESP32.md
+++ b/docs/ESP32.md
@@ -46,7 +46,7 @@ Other options include:
 esptool.py - use the following command syntax:
 
 ```bash
-esptool.py write_flash 0x0 tasmota32.factory.bin
+esptool.py write-flash 0x0 tasmota32.factory.bin
 ```
 
 !!! warning "Use a proper power supply!"

--- a/docs/Esptool.md
+++ b/docs/Esptool.md
@@ -37,7 +37,7 @@ Ensure the device is in firmware upload mode.
 
 Backup the current firmware with the following command:
 ```
-esptool.py --port COM5 read-flash 0x00000 0x100000 image1M.bin
+esptool.py --port COM5 read-flash 0x00000 ALL image.bin
 ```
 NOTE: When the command completes the device is out of firmware upload mode!
 

--- a/docs/Esptool.md
+++ b/docs/Esptool.md
@@ -37,7 +37,7 @@ Ensure the device is in firmware upload mode.
 
 Backup the current firmware with the following command:
 ```
-esptool.py --port COM5 read_flash 0x00000 0x100000 image1M.bin
+esptool.py --port COM5 read-flash 0x00000 0x100000 image1M.bin
 ```
 NOTE: When the command completes the device is out of firmware upload mode!
 
@@ -46,7 +46,7 @@ Ensure the device is in firmware upload mode.
 
 Erase the complete flash memory holding the firmware with the following command:
 ```
-esptool.py --port COM5 erase_flash
+esptool.py --port COM5 erase-flash
 ```
 NOTE1: When the command completes the device is out of firmware upload mode!
 
@@ -58,7 +58,7 @@ Ensure the device is in firmware upload mode.
 Load the downloaded Tasmota firmware file *tasmota.bin* with the following command:
 
 ```
-esptool.py --port COM5 write_flash -fs 1MB -fm dout 0x0 tasmota.bin
+esptool.py --port COM5 write-flash -fs 1MB -fm dout 0x0 tasmota.bin
 ```
 NOTE1: When the command completes the device is out of firmware upload mode!
 
@@ -86,11 +86,11 @@ Once the device is in firmware upload mode the following commands are recommende
 
 Erase the flash completely with the following command (substituting the COM port for the one which was used on your computer)
 
-`esptool.exe --port COM5 erase_flash`
+`esptool.exe --port COM5 erase-flash`
 
 Once the erase is complete, reset your device back into programming mode and then upload the firmware using the following command
 
 `
-esptool.exe --port COM5 write_flash -fs 1MB -fm dout 0x0 tasmota.bin`
+esptool.exe --port COM5 write-flash -fs 1MB -fm dout 0x0 tasmota.bin`
 
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -131,8 +131,8 @@ To put the ESP into Programming Mode:
 ??? tip "esptool.py programming mode test"
      You can test whether your device is in Programming Mode by attempting to read information from the ESP82xx chip. This requires `esptool.py`. Instructions on installing and using `esptool` are provided below. For example (`COM5` will be your COM port):  
 
-     - `esptool.py -p COM5 read_mac` (It should read the MAC address. It may fail afterwards during Uploading and running a "stub". This is normal.)
-     - `esptool.py -p COM5 flash_id`
+     - `esptool.py -p COM5 read-mac` (It should read the MAC address. It may fail afterwards during Uploading and running a "stub". This is normal.)
+     - `esptool.py -p COM5 flash-id`
 
 If everything went well, you are now in Programming Mode and ready to continue with [flashing](#flashing). If the flashing process is unable to start, disconnect the device and retry the steps.
 
@@ -222,14 +222,14 @@ Choose an installation method:
     #### Backup Firmware <small>(optional step)</small>
     Backup the current firmware with the following command:
     ```
-    esptool.py --port COM5 read_flash 0x00000 0x100000 fwbackup.bin
+    esptool.py --port COM5 read-flash 0x00000 0x100000 fwbackup.bin
     ```
     *When the command completes the device is not in programming mode anymore.* Repeat the process of putting your device in programming mode.
 
     #### Erase Flash Memory
     Erase the complete flash memory holding the firmware with the following command:
     ```
-    esptool.py --port COM5 erase_flash
+    esptool.py --port COM5 erase-flash
     ```
     It only takes a few seconds to erase 1M of flash.
 
@@ -239,14 +239,14 @@ Choose an installation method:
     Load the chosen Tasmota firmware file with the following command (e.g., `tasmota.bin` in this example):
 
     ```
-    esptool.py write_flash -fm dout 0x0 tasmota.bin
+    esptool.py write-flash -fm dout 0x0 tasmota.bin
     ```
     or for ESP32:
     !!! note
         _Factory_ binaries are used for inital flashing this time
         https://ota.tasmota.com/tasmota32/release/
     ```
-    esptool.py write_flash 0x0 tasmota32.factory.bin
+    esptool.py write-flash 0x0 tasmota32.factory.bin
     ```
 
     Unplug your serial programming adapter or your device and plug it back in or connect to another power source. Your device is now ready for [Initial configuration](#initial-configuration). 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -222,7 +222,7 @@ Choose an installation method:
     #### Backup Firmware <small>(optional step)</small>
     Backup the current firmware with the following command:
     ```
-    esptool.py --port COM5 read-flash 0x00000 0x100000 fwbackup.bin
+    esptool.py --port COM5 read-flash 0x00000 ALL fwbackup.bin
     ```
     *When the command completes the device is not in programming mode anymore.* Repeat the process of putting your device in programming mode.
 

--- a/docs/devices/BlitzWolf-SHP6.md
+++ b/docs/devices/BlitzWolf-SHP6.md
@@ -61,7 +61,7 @@ Erase flash to avoid issues with dropping WiFi connection.
 
 Example using esptool:
 ```
-esptool.py --port COM3 erase_flash
+esptool.py --port COM3 erase-flash
 ```
 
 ### Step 8

--- a/docs/devices/H801.md
+++ b/docs/devices/H801.md
@@ -37,7 +37,7 @@ Most boards supported by the Tasmota firmware use GPIO 1 for serial TX. The H801
 
 See [#2155](https://github.com/arendst/Tasmota/issues/2155) for more details.
 
-Please be aware that some of the H801 modules were sold with only 512kB of flash. You can check whether yours is affected by using esptool, with the flash_id command. If you only have 512kB of flash, you can still build your own firmware, but will have to remove components that you do not need, in order to reduce the size of the firmware binary. You will also have to use a linker script for the smaller flash. For an example, see [this issue](https://github.com/arendst/Tasmota/issues/2982)
+Please be aware that some of the H801 modules were sold with only 512kB of flash. You can check whether yours is affected by using esptool, with the flash-id command. If you only have 512kB of flash, you can still build your own firmware, but will have to remove components that you do not need, in order to reduce the size of the firmware binary. You will also have to use a linker script for the smaller flash. For an example, see [this issue](https://github.com/arendst/Tasmota/issues/2982)
 
 ## Known Issue
 While powering up there is a short but bright light flash emitted from the strip. 

--- a/docs/devices/LSC-Smart-Connect-Smart-Power-Plug.md
+++ b/docs/devices/LSC-Smart-Connect-Smart-Power-Plug.md
@@ -13,9 +13,9 @@ Simply connect the (clearly labeled) 3v3, GND, TX, RX pins of the TYWE2S to the 
 
 With the device connected and in flashing mode, create a backup of the factory firmware, erase the flash, and flash a tasmota firmware approximately as follows:
 
-    esptool.py read_flash 0x000000 0x100000 image1M.bin
-    esptool.py erase_flash
-    esptool.py write_flash -fs 1MB -fm dout 0x0 tasmota-lite.bin`
+    esptool.py read-flash 0x000000 0x100000 image1M.bin
+    esptool.py erase-flash
+    esptool.py write-flash -fs 1MB -fm dout 0x0 tasmota-lite.bin`
 
 ## Configuration
 ⚠️ Warning! While the below configuration is correct and working, configuring a button on GPIO14 will make the device reset itself to the default Tasmota configuration after a number of seconds.

--- a/docs/devices/Sonoff-Slampher.md
+++ b/docs/devices/Sonoff-Slampher.md
@@ -10,7 +10,7 @@ After much screwing around, I discovered that simply holding the button while I 
 I flashed it from a mac terminal window like so:
 
 ```shellsession
-esptool.py --port /dev/tty.usbserial-A60226NF write_flash -fs 1MB -fm dout 0x0 ~/Downloads/tasmota.bin
+esptool.py --port /dev/tty.usbserial-A60226NF write-flash -fs 1MB -fm dout 0x0 ~/Downloads/tasmota.bin
 ```
 
 The barcode on the box for the device that I received is 6920075757361, it's also labeled with MPN:IM190528001.  

--- a/docs/devices/Xiaomi-Mi-Desk-Lamp.md
+++ b/docs/devices/Xiaomi-Mi-Desk-Lamp.md
@@ -96,7 +96,7 @@ As there is plenty of free space in the lamp stand, I left the wires long enough
 
 The rest of the serial flashing process is [as usual](../Getting-Started#hardware-preparation), but if you want to make a backup of the original firmware, keep in mind that the flash size is **2 MBs**.
 
-If you are re-flashing the original firmware, the flash size must be explicitly set to '2MB-c1', **the auto-detected '2MB' doesn't work**, so: `esptool.py write_flash --flash_size 2MB-c1 0x00000 xiaomi_desk_lamp.orig.bin`
+If you are re-flashing the original firmware, the flash size must be explicitly set to '2MB-c1', **the auto-detected '2MB' doesn't work**, so: `esptool.py write-flash --flash-size 2MB-c1 0x00000 xiaomi_desk_lamp.orig.bin`
 
 
 ## Serial logging


### PR DESCRIPTION
Noticed that the commands here are still using the deprecated format with `_`: https://docs.espressif.com/projects/esptool/en/latest/esp32/migration-guide.html#command-and-option-renaming
Also backups should read `ALL` instead of only 1M of the flash