### PR TITLE
Update AM2301.md - fix GPIO default to stop null reads

### DIFF
--- a/docs/AM2301.md
+++ b/docs/AM2301.md
@@ -60,7 +60,7 @@ Like the [Wemos DHT11 shield specs](https://docs.wemos.cc/en/latest/d1_mini_shil
 ### Tasmota Settings
 In the **_Configuration -> Configure Module_** page assign:
 
-1. GPIO2 to `AM2301 (2)`
+1. GPIOx to `AM2301 (2)` - Do not use GPIO2 as reading will not be available after a soft reboot.
 
 ## Sensors
 Read more about [differences between sensors](http://www.kandrsmith.org/RJS/Misc/Hygrometers/calib_many.html).


### PR DESCRIPTION
Thank for the great work in this project!

Edited GPIO selection. If using GPIO2 for the sensor, and soft rebooting the unit all you get is null readings. Saw the issue on a number posts on line after I had the same issues follwoing the default details. Easy fix is to use other GPIO pins.