### PR TITLE
[DOC: PIR Motion Sensors] Fix MQTT topic to publish config for Home Assistant

### DIFF
--- a/docs/PIR-Motion-Sensors.md
+++ b/docs/PIR-Motion-Sensors.md
@@ -96,7 +96,7 @@ Backlog rule1 on switch2#state do publish stat/%topic%/MOTION %value% endon; rul
 3. Run this very-long command all at once:
 
 ```console
-rule2 on system#boot do publish2 homeassistant/%topic%/config {
+rule2 on system#boot do publish2 homeassistant/binary_sensor/%topic%/config {
   "name": "Motion Sensor",
   "state_topic": "stat/%topic%/MOTION",
   "payload_on": 1,


### PR DESCRIPTION
I noticed that with the suggested topic in rule2,  Home assistant doesn't detect the device/sensor. 
After some digging with MQTT explorer I discovered that MQTT integration requires a particular structure of the topic tree under `/homeassistant` .  Sensors configuration should be nested under their type parent-topics, e.g. `/homeassistant/sensor/<Sensor ID>`, or in that case `/homeassistant/binary_sensor/<Sensor ID>` . 
Also, not included in the PR is additional parameter for the device:
```
rule2 on system#boot do publish2 homeassistant/binary_sensor/%topic%/config {
  "name": "Motion Sensor",
  "state_topic": "stat/%topic%/MOTION",
  "payload_on": 1,
  "availability_topic": "tele/%topic%/LWT",
  "payload_available": "Online",
  "payload_not_available": "Offline",
  "device_class": "motion",
  "force_update": true,
  "off_delay": 30,
  "unique_id": "%deviceid%_motion",
  "device": {
    "identifiers": [
      "%deviceid%"
    ],
    "name": "WeMos D1 Mini" // Just an example, could be "%deviceid%"
  }
} endon
```
Without the name added to the device parameters, HA shows the sensor as `Connected via Unnamed device`
<img width="978" height="418" alt="image" src="https://github.com/user-attachments/assets/252de449-b72e-491f-a14a-ef195fc558f6" />
