### PR TITLE
Documents imcompatible drivers with TM1650

### DIFF
--- a/docs/TM1650.md
+++ b/docs/TM1650.md
@@ -27,6 +27,28 @@
     #endif
 
     ```
+    
+    -----------------------------------------------------
+    
+    From version 14.4.1 onwards, you must also add this:
+    ```c++
+    #ifdef USE_DISPLAY_LCD
+      #undef USE_DISPLAY_LCD
+    #endif
+
+    #ifdef USE_DISPLAY_SEVENSEG
+      #undef USE_DISPLAY_SEVENSEG
+    #endif
+
+    ```
+    
+    or simply disable those I2C drivers from the console:
+    ```c++
+    I2cDriver3 0
+    I2CDriver47 0
+    
+    ```    
+    
 
 | TM1650 - XY-Clock | TM1650 - 303WiFiLC01 |
 |:---:|:---:|


### PR DESCRIPTION
From version 14.4.1,   I2C drivers 3 and 47 are incompatible with the TM1650 display.

See [Tasmota issue 24298](https://github.com/arendst/Tasmota/issues/24298)

_I've successfully tested disabling I2Cdrivers in v14.4.1 & v15.2.0_