### PR TITLE
Fix NeoPool SENSOR JSON key: "Module" → "Modules"

### DIFF
--- a/docs/NeoPool.md
+++ b/docs/NeoPool.md
@@ -134,7 +134,7 @@ Sensor data is sent via the Tasmota topic `tele/%topic%/SENSOR` in JSON format e
   "NeoPool": {
     "Time": "2021-06-01T11:00:00",
     "Type": "Oxilife",
-    "Module": {
+    "Modules": {
       "pH": 1,
       "Redox": 1,
       "Hydrolysis": 1,
@@ -312,11 +312,11 @@ Connection.MBRegData|(Int) Err 13: Register data not specified
 Connection.MBTooManyReg|(Int) Err 14: To many registers
 Connection.MBUnknownErr|(Int) Unknown errors occured
 
-The JSON values `pH`, `Redox`, `Hydrolysis`, `Chlorine`, `Conductivity` and `Ionization` are only available if the corresponding module is installed in the device (the corresponding "Module" subkey must be `1`).
+The JSON values `pH`, `Redox`, `Hydrolysis`, `Chlorine`, `Conductivity` and `Ionization` are only available if the corresponding module is installed in the device (the corresponding "Modules" subkey must be `1`).
 
 The `Relay` subkeys `Acid`, `Base`, `Redox`, `Chlorine`, `Conductivity`, `Heating`, `UV` and `Valve` are only available if the related function is assigned to a relay.
 
-To check which modules are installed use the `Module` value from SENSOR topic or query it manually by using the [NPControl](#npcontrol) command:
+To check which modules are installed use the `Modules` value from SENSOR topic or query it manually by using the [NPControl](#npcontrol) command:
 
 ```json
 {


### PR DESCRIPTION
The NeoPool SENSOR telemetry JSON uses `"Modules"` (plural) as the key name, but the documentation shows `"Module"` (singular) in the example payload and descriptive text.

The Tasmota source code confirms `"Modules"` is correct:
- `xsns_83_neopool.ino` defines `D_NEOPOOL_JSON_MODULES = "Modules"`
- The NPControl example in this same doc already correctly uses `"Modules"`

This was discussed with @curzon01, who requested the fix [here](https://community.home-assistant.io/t/ha-neopool-mqtt-integration-of-tasmota-neopool-for-sugar-valley-hayward-aquarite-bayrol-devices/632517/538).

### Changes (3 lines in `docs/NeoPool.md`)

**Line 137** — SENSOR JSON example:
```diff
-    "Module": {
+    "Modules": {
```

**Line 315** — Description text:
```diff
- ...the corresponding "Module" subkey must be `1`)
+ ...the corresponding "Modules" subkey must be `1`)
```

**Line 319** — Reference to SENSOR topic:
```diff
- To check which modules are installed use the `Module` value from SENSOR topic
+ To check which modules are installed use the `Modules` value from SENSOR topic
```