### PR TITLE
Update IR remote code for protocol SONY

### DIFF
--- a/docs/Codes-for-IR-Remotes.md
+++ b/docs/Codes-for-IR-Remotes.md
@@ -257,7 +257,7 @@ Common buttons should work across multiple models
 | 8                   | {"Protocol":"SONY","Bits":12,"Data":"0xE10"}  |
 | 9                   | {"Protocol":"SONY","Bits":12,"Data":"0x110"}  |
 | Text                | {"Protocol":"SONY","Bits":12,"Data":"0xFD0"}  |
-| 0                   | {"Protocol":"SONY","Bits":12,"Data":"0x110"}  |
+| 0                   | {"Protocol":"SONY","Bits":12,"Data":"0x910"}  |
 | Subtitles           | {"Protocol":"SONY","Bits":15,"Data":"0x0AE9"} |
 | Audio Track         | {"Protocol":"SONY","Bits":12,"Data":"0xE90"}  |
 | HDMI 1              | {"Protocol":"SONY","Bits":15,"Data":"0x2D58"} |


### PR DESCRIPTION
## Description

Fixes the documented IR code for the Sony KDL-EX540 TV zero button.

The zero button was listed with the same code as button 9 (`0x110`).

This updates the zero button code to:

```text
0x910
```

while leaving the button 9 code unchanged.
