### PR TITLE
Update GPIO16 warning for DS18x20 documentation

### DIFF
--- a/docs/DS18x20.md
+++ b/docs/DS18x20.md
@@ -21,7 +21,10 @@ DS18x20 driver supports [DS18B20](https://www.maximintegrated.com/en/products/se
 |2 Data  |GPIOx   |
 |3 VCC   |3.3v   |
 
-!!! Warning "Warning: DS18x20 will not work on GPIO16"
+!!! Warning "Warning: GPIO16"
+    On the ESP8266, DS18x20 will not work on GPIO16.
+    On the ESP32 WROVER modules, GPIO16 is used by PSRAM so it should be avoided.
+    There are no restrictions on using GPIO16 for DS18x20 sensors on ESP32 WROOM modules.
 
 You need to connect a 4.7K pullup resistor from data to 3.3V.   
 ![Wiring](https://user-images.githubusercontent.com/5904370/68093499-5b310700-fe96-11e9-8d50-2be9982a59f2.png)


### PR DESCRIPTION
Clarified warning regarding GPIO16 usage for DS18x20 sensors on ESP8266 and ESP32.