### PR TITLE
Document TFA Marbella pool thermometer and SetOption166

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -650,6 +650,7 @@ SetOption162<a class="cmnd" id="setoption162"></a>|Do not add export energy to e
 SetOption163<a class="cmnd" id="setoption163"></a>|Disable display of webUI device name
 SetOption164<a class="cmnd" id="setoption164"></a>|Enable WiZ Smart Remote support
 SetOption165<a class="cmnd" id="setoption165"></a>|Allow TLS ECDSA certificates<br>`0` = allow only RSA certificates<br>`1` = allow both RSA and ECDSA certificates<br>Because letsencrypt nod defaults to ECDSA certificates, in case of TLS error 296 (unsupported cipher), `SetOption165 1` is automatically enabled.
+SetOption166<a class="cmnd" id="setoption166"></a>|Publish [TFA Marbella](TFA-Marbella) readings as they arrive<br>`0` = *(default)* readings are sent with the regular `TelePeriod` telemetry<br>`1` = additionally publish each reading as soon as it is received. The sensor transmits about once a minute, so with the default `TelePeriod` of 300 seconds most readings would otherwise never be sent.
               
 ### TuyaMCU
 

--- a/docs/Supported-Peripherals.md
+++ b/docs/Supported-Peripherals.md
@@ -130,6 +130,7 @@ DS3502 | Digital potentiometer| I^2^C
 **T6703**<BR>**T6713** | Telaire T6700 series CO~2~ sensor | I^2^C
 [**TC74**](https://github.com/arendst/Tasmota/blob/development/tasmota/tasmota_xsns_sensor/xsns_108_tc74.ino) | Temperature sensor| I^2^C
 [**Téléinfo**](Teleinfo) | French energy measuring system | serial
+[**TFA Marbella**](TFA-Marbella) | 868MHz pool thermometer (30.3066.01) via CC1101 | SPI
 **TFMini** | TFmini, TFmini Plus, TFmini Plus (indoor Version), TFmini-S LiDAR module | serial
 **TM1638** | 8 Switch, LED and 7-segment unit sensor| gpio
 [**TSL2561**](TSL2561) | Luminosity sensor| I^2^C

--- a/docs/TFA-Marbella.md
+++ b/docs/TFA-Marbella.md
@@ -1,0 +1,104 @@
+# TFA Marbella pool thermometer
+
+??? failure "This feature is not included in precompiled binaries"
+
+    When [compiling your build](Compile-your-build) add the following to `user_config_override.h`:
+    ```arduino
+    #define USE_SPI                         // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
+    #define USE_TFA_MARBELLA                // Add support for TFA Dostmann Marbella 868MHz pool thermometer using a CC1101 (+12k6 code on ESP8266, +5k7 on ESP32)
+      #define TFA_MARBELLA_TIMEOUT   900    // Seconds without a packet after which the reading is dropped
+      #define TFA_MARBELLA_SERIAL    0      // Sensor id to bind to, 0 learns the first sensor received
+    ```
+
+The [TFA Dostmann Marbella](https://www.tfa-dostmann.de/produkt/funk-poolthermometer-marbella-30-3066/) (30.3066.01) is a floating pool thermometer that transmits the water temperature on 868 MHz about once a minute. Tasmota receives it with a CC1101 module and reports temperature, sensor id, rolling counter and battery state.
+
+The sensor is receive-only from Tasmota's point of view: there is nothing to pair, no button to press, and the display that comes with the thermometer keeps working alongside.
+
+## Wiring
+
+The CC1101 shares the SPI bus with any other SPI peripheral. Only chip select and GDO0 belong to the module itself.
+
+| CC1101  | ESP8266        | Tasmota      |
+| ------- | -------------- | ------------ |
+|  CSN    | GPIO0..5,15,16 |  CC1101 CS   |
+|  GDO0   | GPIO0..5,15,16 |  CC1101 GDO0 |
+|  SCK    | GPIO14         |  SPI CLK     |
+|  MOSI   | GPIO13         |  SPI MOSI    |
+|  MISO   | GPIO12         |  SPI MISO    |
+|  GDO2   | not used       |              |
+|  GND    | GND            |              |
+|  3V3    | 3V3            |              |
+
+!!! note
+    `SPI CLK`, `SPI MOSI` and `SPI MISO` are the shared bus lines - assign them once, even if several SPI devices are connected. `CC1101 CS` and `CC1101 GDO0` are specific to this module.
+
+An 868 MHz antenna is required. The wire antennas that come with common CC1101 breakout boards are cut for 433 MHz and will work poorly; a quarter wave for 868 MHz is about 8.6 cm.
+
+## Configuration
+
+Set the GPIOs in **Configuration - Configure Module** as listed above. After a restart the driver starts listening and binds itself to the first sensor it receives with a valid checksum:
+
+```
+MRB: TFA Marbella receiver started
+MRB: Bound to sensor 68B94A
+```
+
+From then on every other sensor is ignored, so an identical thermometer next door cannot feed readings into the same value.
+
+## Commands
+
+Command|Parameters
+:---|:---
+Marbella|Show the bound sensor id and the reception state<br>`<id>` = bind to one sensor, id as six hex digits, e.g. `683f16`<br>`0` = forget the binding and learn the next sensor seen
+
+The binding is stored and survives a restart, so the receiver cannot bind itself to a neighbour's sensor while yours happens to be quiet. `TFA_MARBELLA_SERIAL` sets it at compile time instead.
+
+[`SetOption166`](Commands#setoption166) additionally publishes each reading as it arrives instead of leaving it to `TelePeriod`. Useful here, because the sensor transmits about once a minute while the default `TelePeriod` is 300 seconds.
+
+## Web interface
+
+The sensor section shows temperature and battery state:
+
+```
+TFA Marbella Temperature    33.4 °C
+TFA Marbella Battery        ok
+```
+
+The battery line is always shown, not only when the battery is low - a line that appears only in the bad case cannot be told apart from a driver that does not report it at all. It reads `low - replace` when the sensor raises the flag.
+
+## Sensor output
+
+```json
+{"TFAMarbella":{"Id":"68B94A","Temperature":30.5,"Counter":0,"BatteryLow":0,"LQI":4},"TempUnit":"C"}
+```
+
+Id
+: Serial number of the sensor, changes only when the sensor is reset
+
+Temperature
+: Water temperature
+
+Counter
+: 3 bit rolling counter, increments with every transmission - useful to spot lost packets
+
+BatteryLow
+: `1` when the sensor reports a low battery, `0` when it is fine. The sensor sends a single bit, not a level - hence `BatteryLow` and not `Battery`, which is a percentage elsewhere in Tasmota
+
+LQI
+: Link quality of the packet, `0` to `127`, **lower is better** - it counts how far the symbols fell from their expected positions, so `0` is a flawless frame. Note that this is the opposite of the LQI reported by Zigbee transceivers, where a high value means a good link. The RSSI the chip appends to each packet is not reported: RadioLib keeps it in a private field, and the register that remains readable holds the noise floor by the time the frame is complete
+
+Every frame carries a checksum, and frames that fail it are discarded. If nothing is received for `TFA_MARBELLA_TIMEOUT` seconds the reading disappears from the telemetry and the web interface rather than showing a value that has silently stopped updating.
+
+Reception restarts itself after three minutes without a valid frame. The CC1101 can end up waiting in RX without signalling again, and nothing would ever wake it - the reading would just stop. The restart is logged at debug level:
+
+```
+MRB: Receiver re-armed after 180 s without a frame
+```
+
+Seeing that line regularly means frames are being lost for another reason - check the antenna and the LQI before assuming the sensor is at fault.
+
+## Notes
+
+`USE_TFA_MARBELLA` and `USE_KEELOQ` cannot be combined. Both drive the same CC1101, one transmitting on 433 MHz and one receiving on 868 MHz, so the combination fails at compile time.
+
+On ESP32 the driver builds and uses the same RadioLib library, but has not been verified on hardware.


### PR DESCRIPTION
Documentation for the TFA Marbella driver proposed in arendst/Tasmota#24959.

Adds:

- `docs/TFA-Marbella.md` - wiring, configuration, commands, sensor output
- an entry in `docs/Supported-Peripherals.md`
- `SetOption166` in `docs/Commands.md`

The wiring table deliberately separates the shared SPI bus lines from the two roles that belong to the module (`CC1101 CS`, `CC1101 GDO0`), since that is the part that is easy to get wrong. It also mentions the antenna: the wire supplied with common CC1101 breakout boards is cut for 433 MHz, not 868 MHz.

The sensor output section documents `LQI` with an explicit warning that it runs the other way round than the LQI of Zigbee transceivers - 0 to 127 with low being good. It also states why no RSSI is reported: the value the chip appends to the packet is not reachable through RadioLib, and the register that is holds the noise floor by the time the frame is complete, so publishing it would show a plausible number that means nothing.

Note that the driver PR is not merged yet - if the SetOption number changes during review, this page needs the same change.
