### PR TITLE
NeoPool: align documented Hydrolysis.State values with actual JSON output casing

### DIFF
--- a/docs/NeoPool.md
+++ b/docs/NeoPool.md
@@ -269,7 +269,7 @@ Hydrolysis.Runtime.Part|(String) Cell partly runtime
 Hydrolysis.Runtime.Pol1|(String) Cell runtime for polarization 1
 Hydrolysis.Runtime.Pol2|(String) Cell runtime for polarization 2
 Hydrolysis.Runtime.Changes|(Int) Number of polarization changes
-Hydrolysis.State|(String) Cell state:<BR>`OFF` = Cell inactive<BR>`FLOW` = Cell water flow alarm<BR>`POL1` = Cell polarization 1 active<BR>`POL2` = Cell polarization 2 active
+Hydrolysis.State|(String) Cell state:<BR>`OFF` = Cell inactive<BR>`Flow` = Cell water flow alarm<BR>`Pol1` = Cell polarization 1 active<BR>`Pol2` = Cell polarization 2 active
 Hydrolysis.Cover|(Bool) Cover signal input:<BR>`0` = Cover input inactive<BR>`1` = Cover input active
 Hydrolysis.Boost|(Int) Boost mode state:<BR>`0` = Boost mode inactive<BR>`1` = Boost mode active<BR>`2` = Boost mode active with redox control
 Hydrolysis.Low|(Bool) Hydrolysis low alarm:<BR>`0` = No alarm<BR>`1` = Hydrolysis cannot reach the setpoint


### PR DESCRIPTION
## Description

The "SENSOR data description" table documents the `Hydrolysis.State` values as `OFF`/`FLOW`/`POL1`/`POL2` (uppercase), but the driver's actual JSON output on an English build is `OFF`/`Flow`/`Pol1`/`Pol2` — as also shown in the example SENSOR payload earlier on the same page (`"State": "Pol1"`).

This aligns the table with the real output so consumers that compare these values case-sensitively (rules, home automation templates) aren't misled by the docs.

Follow-up to the localized-JSON-keys discussion in alexdelprete/ha-sugar-valley-neopool#22 (refs arendst/Tasmota#24962) — docs PR requested by @curzon01 there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)